### PR TITLE
fix: improve header avatar quality

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -66,7 +66,14 @@ const Header = () => {
         <div className="w-1/4">
           <Link to={siteUrl}>
             <picture>
-              <img className="h-16 w-16 rounded-full" alt="logo" src={logo} />
+              <img
+                className="h-16 w-16 rounded-full object-cover"
+                alt="logo"
+                src={logo}
+                width="64"
+                height="64"
+                decoding="async"
+              />
             </picture>
           </Link>
         </div>

--- a/src/static/site-metadata.ts
+++ b/src/static/site-metadata.ts
@@ -17,7 +17,7 @@ const getBasePath = () => {
 const data: ISiteMetadataResult = {
   siteTitle: 'Activity Page',
   siteUrl: 'https://zaynrun.vercel.app',
-  logo: 'https://avatars.githubusercontent.com/u/45552084?s=48&v=4',
+  logo: 'https://avatars.githubusercontent.com/u/45552084?s=256&v=4',
   description: 'Personal activity records and blog',
   navLinks: [
     {


### PR DESCRIPTION
## Summary

- Request a higher-resolution GitHub avatar for the header logo.
- Keep the rendered avatar at 64x64 while using a 256px source image.
- Add explicit image dimensions, async decoding, and object-cover rendering.

## Verification

- pnpm exec prettier --check src/static/site-metadata.ts src/components/Header/index.tsx
- pnpm run build
- Verified local dev DOM uses `https://avatars.githubusercontent.com/u/45552084?s=256&v=4`