### PR TITLE
fix(ci): trigger ESA deploy after data sync via workflow_run

### DIFF
--- a/.github/workflows/esa_deploy.yml
+++ b/.github/workflows/esa_deploy.yml
@@ -1,12 +1,18 @@
 name: Deploy to ESA Pages
 
 # Deploys the built SPA to Alibaba Cloud ESA (Edge Security Acceleration)
-# Pages. Triggered automatically after run_data_sync.yml commits new run
-# data to master.
+# Pages.
 #
-# Two-job pipeline with a test gate:
-#   test   -> runs Python unittest + frontend lint/build + deploy-config guards
-#   deploy -> only runs if test passes (needs: test), then pushes to ESA edge
+# Triggers:
+#   1. push to master (frontend source or config changes)
+#   2. workflow_run: fires when "Run Data Sync" completes. This is needed
+#      because the sync workflow pushes via GITHUB_TOKEN, whose events do
+#      NOT cascade to other workflows (anti-recursion). workflow_run bridges
+#      that gap.
+#   3. workflow_dispatch (manual)
+#
+# The "should-deploy" gate skips redundant deploys when sync produced no
+# new data (no "update new runs" commit).
 on:
   push:
     branches:
@@ -23,6 +29,10 @@ on:
       - 'esa.jsonc'
       - 'tests/**'
       - '.github/workflows/esa_deploy.yml'
+  workflow_run:
+    workflows: ['Run Data Sync']
+    types: [completed]
+    branches: [master]
   workflow_dispatch:
 
 # Prevent overlapping runs for the same ref.
@@ -31,9 +41,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Gate job: decide whether to deploy. For workflow_run triggers, skip if
+  # the sync produced no new data (avoids empty deploys). For push/manual
+  # triggers, always proceed.
+  should-deploy:
+    name: Check if deploy is needed
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 5
+
+      - name: Check for new synced data
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # For workflow_run: only proceed if the latest commit is a data
+            # sync commit ("update new runs"). If sync had no new data, it
+            # pushes nothing and HEAD stays at the previous commit.
+            LATEST_MSG=$(git log -1 --format='%s')
+            echo "Latest commit: $LATEST_MSG"
+            if echo "$LATEST_MSG" | grep -q "update new runs"; then
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Sync produced no new data — skipping deploy"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # push or workflow_dispatch: always proceed
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Pre-deploy verification
     runs-on: ubuntu-latest
+    needs: should-deploy
+    if: needs.should-deploy.outputs.proceed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,6 +135,7 @@ jobs:
     name: Deploy to ESA edge
     runs-on: ubuntu-latest
     needs: test
+    if: needs.test.result == 'success'
     # Credentials at job level so every step has them without re-declaration.
     # Values live only in GitHub Encrypted Secrets, never in the repo.
     env:


### PR DESCRIPTION
## Problem

Daily data sync (`run_data_sync.yml`) pushes via `GITHUB_TOKEN`. GitHub's anti-recursion rule prevents `GITHUB_TOKEN` pushes from triggering other workflows, so `update new runs` commits **never fired** `esa_deploy.yml`. The site stayed stale despite fresh data.

## Root cause

Confirmed via commit history: every `update new runs` commit (e.g. `0ce1f78` on 7/22) produced zero `esa_deploy` runs. All 3 existing deploy runs were from manual operations today, none from sync.

## Fix

Add `workflow_run` trigger to `esa_deploy.yml` that fires when `Run Data Sync` completes. A `should-deploy` gate job checks whether sync actually produced a new `update new runs` commit — skips deploy if no new data (avoiding empty redundant builds).

```
data sync → push (GITHUB_TOKEN) → workflow_run → should-deploy → test → deploy
```

## Verification
- [x] YAML syntax valid
- [x] Deployment config guard tests (15) pass
- [ ] CI green
- [ ] Manual sync trigger produces a deploy run