### PR TITLE
fix(ci): harden deploy pipeline reliability (code review)

### DIFF
--- a/.github/workflows/esa_deploy.yml
+++ b/.github/workflows/esa_deploy.yml
@@ -35,10 +35,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
-# Prevent overlapping runs for the same ref.
+# Queue (do not cancel) deploys so an in-flight build+deploy is never
+# aborted mid-way by a newer trigger. For deploy pipelines, cancelling
+# can starve the queue under burst triggers.
 concurrency:
   group: esa-deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Gate job: for workflow_run, only proceed if the triggering sync workflow
@@ -65,7 +67,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: master
+          # Pin to the trigger commit so test and deploy build the exact
+          # same code — avoids shipping a commit that test never validated
+          # when master advances between jobs.
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       # --- Python data + config tests ---
@@ -124,7 +129,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: master
+          # Pin to the same commit the test job validated.
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -147,7 +153,10 @@ jobs:
         run: test -f dist/index.html || { echo "dist/index.html missing"; exit 1; }
 
       - name: Install ESA CLI
-        run: npm install -g esa-cli@latest
+        # Pin to a verified version — @latest risks silent breakage if a
+        # future release changes flag semantics (e.g. --assets/--environment).
+        # Bump explicitly after testing a new version locally.
+        run: npm install -g esa-cli@1.0.11
 
       # GitHub-hosted runners (US) occasionally fail to reach Alibaba Cloud's
       # ESA API on the first attempt. Retry login a few times since esa-cli

--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -291,8 +291,14 @@ jobs:
           git config --local user.email 'action@github.com'
           git config --local user.name 'GitHub Action'
           git add .
-          git commit -m 'update new runs' || echo 'nothing to commit'
-          git push || echo 'nothing to push'
+          # "nothing to commit" is benign (no new data); tolerate it.
+          if ! git commit -m 'update new runs'; then
+            echo 'nothing to commit — no new data this run'
+            exit 0
+          fi
+          # A real push failure (non-fast-forward, permissions, rate limit)
+          # must fail the job — otherwise stale data ships to production.
+          git push
 
       - name: Set Output
         id: set_output

--- a/tests/test_deployment_config.py
+++ b/tests/test_deployment_config.py
@@ -163,25 +163,26 @@ class VercelRemnantTest(unittest.TestCase):
 
 
 class DependencyConsistencyTest(unittest.TestCase):
-    """Ensure package.json dependencies are reflected in the lockfile, so
-    CI installs do not silently drift from declared dependencies."""
+    """Structural checks on the lockfile. Dependency-version consistency is
+    already enforced strictly by `pnpm install --frozen-lockfile` in CI;
+    these tests guard the lockfile's presence and basic validity so a
+    missing or corrupt lockfile is caught early."""
 
-    def test_declared_deps_exist_in_lockfile(self):
-        pkg = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
-        lock = PNPM_LOCK.read_text(encoding="utf-8")
-        declared = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
-        self.assertTrue(declared, "package.json has no dependencies to check")
-        missing = []
-        for dep_name in declared:
-            # pnpm-lock.yaml lists packages as 'dep@version' under dependencies
-            # or importers. A simple substring check on the bare name is a
-            # pragmatic guard against a dep being declared but never locked.
-            if dep_name not in lock:
-                missing.append(dep_name)
-        self.assertEqual(
-            missing,
-            [],
-            f"Declared dependencies missing from pnpm-lock.yaml: {missing}",
+    def test_lockfile_exists_and_nonempty(self):
+        self.assertTrue(
+            PNPM_LOCK.is_file(),
+            "pnpm-lock.yaml must exist for reproducible CI installs",
+        )
+        content = PNPM_LOCK.read_text(encoding="utf-8")
+        self.assertTrue(
+            content.strip(),
+            "pnpm-lock.yaml is empty — run `pnpm install` to generate it",
+        )
+        # pnpm-lock.yaml v9+ starts with "lockfileVersion:".
+        self.assertIn(
+            "lockfileVersion",
+            content,
+            "pnpm-lock.yaml missing lockfileVersion header — may be corrupt",
         )
 
 


### PR DESCRIPTION
## Summary

Production code review found five reliability issues in the ESA deploy pipeline. All fixed here.

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | **critical** | `git push \|\| echo` masked real push failures → sync reported success with data never landing → ESA deployed stale content | Only tolerate "nothing to commit"; push failures now fail the job |
| 2 | medium | `cancel-in-progress: true` could abort mid-build under burst triggers | Changed to `false` (queue instead of cancel) |
| 3 | medium | test and deploy checked out `ref: master` independently → could deploy a commit test never validated | Both pinned to `${{ github.sha }}` |
| 4 | medium | Dependency check was substring match (`react` matched `react-dom`) → false confidence | Replaced with lockfile structural validation; `--frozen-lockfile` already enforces consistency |
| 5 | low | `esa-cli@latest` risks silent breakage | Pinned to `1.0.11` |

## Verification
- [x] YAML syntax valid (both workflows)
- [x] Deployment config guard tests (15) pass
- [x] black + ruff clean
- [ ] CI green