### PR TITLE
feat: add bilingual interface and update birth month

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -45,7 +45,7 @@ env:
   DATA_CACHE_PREFIX: 'track_data'
   SAVE_TO_PARQENT: false # If you want to save the data to the repo, set it to `true`
   GENERATE_MONTH_OF_LIFE: true # If you want to generate the month of life, set it to `true`
-  BIRTHDAY_MONTH: 1989-03 # If you want to generate the month of life, set it to your birthday month, format is YYYY-MM
+  BIRTHDAY_MONTH: 1999-10 # If you want to generate the month of life, set it to your birthday month, format is YYYY-MM
 
 # Serialize sync runs so concurrent triggers (cron + push + manual) do not
 # race on the git push and lose the newer run's data.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN DUMMY=${DUMMY}; \
 RUN python3 run_page/gen_svg.py --from-db --title "my running page" --type grid --athlete "$YOUR_NAME" --output assets/grid.svg --min-distance 10.0 --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime \
   && python3 run_page/gen_svg.py --from-db --title "my running page" --type github --athlete "$YOUR_NAME" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5 \
   && python3 run_page/gen_svg.py --from-db --type circular --use-localtime \
-  && python3 run_page/gen_svg.py --from-db --type monthoflife --birth 1989-03 --special-distance 10 --special-distance2 20 --special-color '#f9d367' --special-color2 '#f0a1a8' --output assets/mol.svg --use-localtime --athlete "$YOUR_NAME" --title 'Runner Month of Life' \
-  && python3 run_page/gen_svg.py --from-db --type monthoflife --birth 1989-03 --special-color "#f9d367"  --special-color2 "#f0a1a8" --output assets/mol_running.svg --use-localtime --athlete "$YOUR_NAME" --title "Runner Month of Life" --sport-type running  \
+  && python3 run_page/gen_svg.py --from-db --type monthoflife --birth 1999-10 --special-distance 10 --special-distance2 20 --special-color '#f9d367' --special-color2 '#f0a1a8' --output assets/mol.svg --use-localtime --athlete "$YOUR_NAME" --title 'Runner Month of Life' \
+  && python3 run_page/gen_svg.py --from-db --type monthoflife --birth 1999-10 --special-color "#f9d367"  --special-color2 "#f0a1a8" --output assets/mol_running.svg --use-localtime --athlete "$YOUR_NAME" --title "Runner Month of Life" --sport-type running  \
   && python3 run_page/gen_svg.py --from-db --type year_summary --output assets/year_summary.svg --athlete "$YOUR_NAME"
 
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <script>

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "dev": "vite dev",
     "serve": "vite serve",
     "lint": "eslint src --ext .ts,.tsx --fix",
-    "check": "prettier --check \"src/main.tsx\" \"src/**/*.{css,module.css,json,ts,tsx}\" \"*.{yaml,json,ts}\"",
-    "format": "prettier --write \"src/main.tsx\" \"src/**/*.{css,module.css,json,ts,tsx}\" \"*.{yaml,json,ts}\"",
-    "ci": "pnpm run format && pnpm run lint && pnpm run build"
+    "check": "prettier --check \"src/main.tsx\" \"src/**/*.{css,module.css,json,ts,tsx}\" \"tests/*.test.mjs\" \"*.{yaml,json,ts}\"",
+    "format": "prettier --write \"src/main.tsx\" \"src/**/*.{css,module.css,json,ts,tsx}\" \"tests/*.test.mjs\" \"*.{yaml,json,ts}\"",
+    "test:unit": "node --test tests/*.test.mjs",
+    "ci": "pnpm run format && pnpm run lint && pnpm run test:unit && pnpm run build"
   },
   "engineStrict": true,
   "browserslist": "defaults, not ie 11",

--- a/src/components/ActivityList/index.tsx
+++ b/src/components/ActivityList/index.tsx
@@ -18,6 +18,7 @@ import {
 } from 'recharts';
 import VirtualList from 'rc-virtual-list';
 import { useNavigate } from 'react-router-dom';
+import LanguageToggle from '@/components/LanguageToggle';
 import activities from '@/static/activities.json';
 import styles from './style.module.css';
 import {
@@ -250,7 +251,7 @@ const ActivityCardInner: React.FC<ActivityCardProps> = ({
     const h = Math.floor(seconds / 3600);
     const m = Math.floor((seconds % 3600) / 60);
     const s = Math.floor(seconds % 60);
-    return `${h}h ${m}m ${s}s`;
+    return IS_CHINESE ? `${h}小时${m}分${s}秒` : `${h}h ${m}m ${s}s`;
   };
 
   const avgSpeedMps = speedDistPerHourToMps(summary.averageSpeed);
@@ -1132,10 +1133,16 @@ const ActivityList: React.FC = () => {
   return (
     <div className={styles.activityList}>
       <div className={styles.filterContainer} ref={filterRef}>
-        <button className={styles.smallHomeButton} onClick={handleHomeClick}>
+        <button
+          type="button"
+          className={styles.smallHomeButton}
+          onClick={handleHomeClick}
+        >
           {HOME_PAGE_TITLE}
         </button>
+        <LanguageToggle className={styles.languageButton} />
         <select
+          aria-label={IS_CHINESE ? '运动类型' : 'Sport type'}
           onChange={(e) => setSportType(e.target.value as SportTypeFilter)}
           value={sportType}
         >
@@ -1150,6 +1157,7 @@ const ActivityList: React.FC = () => {
           ))}
         </select>
         <select
+          aria-label={IS_CHINESE ? '统计周期' : 'Summary interval'}
           onChange={(e) => toggleInterval(e.target.value as IntervalType)}
           value={interval}
         >
@@ -1157,7 +1165,7 @@ const ActivityList: React.FC = () => {
           <option value="month">{ACTIVITY_TOTAL.MONTHLY_TITLE}</option>
           <option value="week">{ACTIVITY_TOTAL.WEEKLY_TITLE}</option>
           <option value="day">{ACTIVITY_TOTAL.DAILY_TITLE}</option>
-          <option value="life">Life</option>
+          <option value="life">{IS_CHINESE ? '生涯' : 'Life'}</option>
         </select>
       </div>
 
@@ -1177,7 +1185,7 @@ const ActivityList: React.FC = () => {
               </button>
             ))}
           </div>
-          <Suspense fallback={<div>Loading SVG...</div>}>
+          <Suspense fallback={<div>{LOADING_TEXT}</div>}>
             {selectedYear ? (
               // Show Year Summary SVG when a year is selected
               (() => {

--- a/src/components/ActivityList/style.module.css
+++ b/src/components/ActivityList/style.module.css
@@ -150,18 +150,26 @@
   margin-top: 10px;
 }
 
-.smallHomeButton {
-  width: 90px;
+.smallHomeButton,
+.languageButton {
   padding: 4px 12px;
   background-color: var(--color-primary);
   color: var(--color-background);
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  margin-right: 20px;
 }
 
-.smallHomeButton:hover {
+.smallHomeButton {
+  width: 90px;
+}
+
+.languageButton {
+  min-width: 44px;
+}
+
+.smallHomeButton:hover,
+.languageButton:hover {
   background-color: var(--color-secondary);
 }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import useSiteMetadata from '@/hooks/useSiteMetadata';
 import { useTheme, Theme } from '@/hooks/useTheme';
 import styles from './style.module.css';
+import { IS_CHINESE } from '@/utils/const';
+import LanguageToggle from '@/components/LanguageToggle';
 
 const Header = () => {
   const { logo, siteUrl, navLinks } = useSiteMetadata();
@@ -59,6 +61,15 @@ const Header = () => {
   };
 
   const currentIcon = icons[currentIconIndex];
+  const nextTheme = icons[(currentIconIndex + 1) % icons.length].id;
+  const themeLabel =
+    nextTheme === 'dark'
+      ? IS_CHINESE
+        ? '切换到深色主题'
+        : 'Switch to dark theme'
+      : IS_CHINESE
+        ? '切换到浅色主题'
+        : 'Switch to light theme';
 
   return (
     <>
@@ -82,18 +93,21 @@ const Header = () => {
             <a
               key={i}
               href={n.url}
-              className="mr-3 text-lg lg:mr-4 lg:text-base"
+              className="mr-2 text-sm lg:mr-4 lg:text-base"
             >
               {n.name}
             </a>
           ))}
-          <div className="ml-4 flex items-center space-x-2">
+          <div className="ml-2 flex items-center space-x-1 lg:ml-4 lg:space-x-2">
+            <LanguageToggle
+              className={`${styles.themeButton} ${styles.themeButtonActive}`}
+            />
             <button
               type="button"
               onClick={handleToggle}
               className={`${styles.themeButton} ${styles.themeButtonActive}`}
-              aria-label={`Switch to ${currentIcon.id} theme`}
-              title={`Switch to ${currentIcon.id} theme`}
+              aria-label={themeLabel}
+              title={themeLabel}
             >
               <div className={styles.iconWrapper}>{currentIcon.svg}</div>
             </button>

--- a/src/components/Header/style.module.css
+++ b/src/components/Header/style.module.css
@@ -10,6 +10,13 @@
   position: relative;
 }
 
+@media only screen and (max-width: 768px) {
+  .themeButton {
+    width: 36px;
+    height: 36px;
+  }
+}
+
 .themeButton:hover {
   background-color: var(--color-run-row-hover-background);
 }

--- a/src/components/LanguageToggle/index.tsx
+++ b/src/components/LanguageToggle/index.tsx
@@ -1,0 +1,37 @@
+import { IS_CHINESE } from '@/utils/const';
+import { persistLanguage, type Language } from '@/utils/language';
+
+interface LanguageToggleProps {
+  className?: string;
+}
+
+const LanguageToggle = ({ className }: LanguageToggleProps) => {
+  const nextLanguage: Language = IS_CHINESE ? 'en' : 'zh-CN';
+  const label = IS_CHINESE ? '切换到英文' : 'Switch to Chinese';
+
+  const handleClick = () => {
+    if (!persistLanguage(nextLanguage)) {
+      window.alert(
+        IS_CHINESE
+          ? '无法保存语言设置，请检查浏览器存储权限。'
+          : 'Unable to save the language setting. Check browser storage permissions.'
+      );
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleClick}
+      aria-label={label}
+      title={label}
+    >
+      {IS_CHINESE ? 'EN' : '中'}
+    </button>
+  );
+};
+
+export default LanguageToggle;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,27 +1,29 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { Helmet } from 'react-helmet-async';
+import React, { useEffect } from 'react';
 import Header from '@/components/Header';
 import useSiteMetadata from '@/hooks/useSiteMetadata';
+import { IS_CHINESE } from '@/utils/const';
 
 const Layout = ({ children }: React.PropsWithChildren) => {
   const { siteTitle, description } = useSiteMetadata();
 
+  useEffect(() => {
+    document.documentElement.lang = IS_CHINESE ? 'zh-CN' : 'en';
+    document.title = siteTitle;
+
+    let descriptionMeta = document.querySelector<HTMLMetaElement>(
+      'meta[name="description"]'
+    );
+    if (!descriptionMeta) {
+      descriptionMeta = document.createElement('meta');
+      descriptionMeta.name = 'description';
+      document.head.append(descriptionMeta);
+    }
+    descriptionMeta.content = description;
+  }, [description, siteTitle]);
+
   return (
     <>
-      <Helmet>
-        <html lang="en" />
-        <title>{siteTitle}</title>
-        <meta name="description" content={description} />
-        <meta
-          name="keywords"
-          content="activity,sports,running,cycling,hiking,walking"
-        />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, shrink-to-fit=no"
-        />
-      </Helmet>
       <Header />
       <div className="mx-auto mb-16 max-w-screen-2xl p-4 lg:flex lg:p-16">
         {children}

--- a/src/components/LocationStat/LocationSummary.tsx
+++ b/src/components/LocationStat/LocationSummary.tsx
@@ -1,5 +1,6 @@
 import Stat from '@/components/Stat';
 import useActivities from '@/hooks/useActivities';
+import { IS_CHINESE } from '@/utils/const';
 
 // only support China for now
 const LocationSummary = () => {
@@ -8,16 +9,28 @@ const LocationSummary = () => {
     <div className="cursor-pointer">
       <section>
         {years ? (
-          <Stat value={`${years.length}`} description=" 年里我跑过" />
+          <Stat
+            value={`${years.length}`}
+            description={IS_CHINESE ? ' 年运动记录' : ' years of records'}
+          />
         ) : null}
         {countries ? (
-          <Stat value={countries.length} description=" 个国家" />
+          <Stat
+            value={countries.length}
+            description={IS_CHINESE ? ' 个国家' : ' countries'}
+          />
         ) : null}
         {provinces ? (
-          <Stat value={provinces.length} description=" 个省份" />
+          <Stat
+            value={provinces.length}
+            description={IS_CHINESE ? ' 个省份' : ' provinces'}
+          />
         ) : null}
         {cities ? (
-          <Stat value={Object.keys(cities).length} description=" 个城市" />
+          <Stat
+            value={Object.keys(cities).length}
+            description={IS_CHINESE ? ' 个城市' : ' cities'}
+          />
         ) : null}
       </section>
       <hr />

--- a/src/components/LocationStat/PeriodStat.tsx
+++ b/src/components/LocationStat/PeriodStat.tsx
@@ -1,5 +1,6 @@
 import Stat from '@/components/Stat';
 import useActivities from '@/hooks/useActivities';
+import { IS_CHINESE } from '@/utils/const';
 
 const PeriodStat = ({ onClick }: { onClick: (_period: string) => void }) => {
   const { runPeriod } = useActivities();
@@ -13,7 +14,9 @@ const PeriodStat = ({ onClick }: { onClick: (_period: string) => void }) => {
           <Stat
             key={period}
             value={period}
-            description={` ${times} Activities`}
+            description={
+              IS_CHINESE ? ` ${times} 次活动` : ` ${times} activities`
+            }
             citySize={3}
             onClick={() => onClick(period)}
           />

--- a/src/components/LocationStat/index.tsx
+++ b/src/components/LocationStat/index.tsx
@@ -1,7 +1,7 @@
 import YearStat from '@/components/YearStat';
 import {
-  CHINESE_LOCATION_INFO_MESSAGE_FIRST,
-  CHINESE_LOCATION_INFO_MESSAGE_SECOND,
+  LOCATION_INFO_MESSAGE_FIRST,
+  LOCATION_INFO_MESSAGE_SECOND,
 } from '@/utils/const';
 import CitiesStat from './CitiesStat';
 import LocationSummary from './LocationSummary';
@@ -21,14 +21,9 @@ const LocationStat = ({
   <div className="w-full pb-16 lg:w-full lg:pr-16">
     <section className="pb-0">
       <p className="leading-relaxed">
-        {CHINESE_LOCATION_INFO_MESSAGE_FIRST}
-        .
+        {LOCATION_INFO_MESSAGE_FIRST}
         <br />
-        {CHINESE_LOCATION_INFO_MESSAGE_SECOND}
-        .
-        <br />
-        <br />
-        Yesterday you said tomorrow.
+        {LOCATION_INFO_MESSAGE_SECOND}
       </p>
     </section>
     <hr />

--- a/src/components/RunMap/LightsControl.tsx
+++ b/src/components/RunMap/LightsControl.tsx
@@ -1,4 +1,5 @@
 import styles from './style.module.css';
+import { IS_CHINESE } from '@/utils/const';
 
 interface ILightsProps {
   setLights: (_lights: boolean) => void;
@@ -6,17 +7,21 @@ interface ILightsProps {
 }
 
 const LightsControl = ({ setLights, lights }: ILightsProps) => {
+  const label = IS_CHINESE
+    ? lights
+      ? '隐藏地图底图'
+      : '显示地图底图'
+    : `Turn ${lights ? 'off' : 'on'} the map background`;
   return (
     <div className={'mapboxgl-ctrl mapboxgl-ctrl-group  ' + styles.lights}>
       <button
+        type="button"
+        aria-label={label}
+        title={label}
         className={`${lights ? styles.lightsOn : styles.lightsOff}`}
         onClick={() => setLights(!lights)}
       >
-        <span
-          className="mapboxgl-ctrl-icon"
-          aria-hidden="true"
-          title={'Turn ' + `${lights ? 'off' : 'on'}` + ' the Light'}
-        ></span>
+        <span className="mapboxgl-ctrl-icon" aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/components/RunMap/RunMapButtons.tsx
+++ b/src/components/RunMap/RunMapButtons.tsx
@@ -1,5 +1,6 @@
 import useActivities from '@/hooks/useActivities';
 import styles from './style.module.css';
+import { IS_CHINESE } from '@/utils/const';
 
 const RunMapButtons = ({
   changeYear,
@@ -24,7 +25,7 @@ const RunMapButtons = ({
             changeYear(year);
           }}
         >
-          {year}
+          {year === 'Total' && IS_CHINESE ? '全部' : year}
         </li>
       ))}
     </ul>

--- a/src/components/RunMap/index.tsx
+++ b/src/components/RunMap/index.tsx
@@ -148,7 +148,9 @@ const RunMap = ({
       const handleStyleError = (e: any) => {
         console.error('❌ Map style failed to load:', e);
         setMapError(
-          'Map tiles failed to load. Please check your internet connection.'
+          IS_CHINESE
+            ? '地图加载失败，请检查网络连接。'
+            : 'Map tiles failed to load. Please check your internet connection.'
         );
 
         if (MAP_TILE_VENDOR === 'mapcn') {
@@ -443,13 +445,15 @@ const RunMap = ({
       {mapError && (
         <div className={styles.mapErrorNotification}>
           <span>⚠️ {mapError}</span>
-          <button onClick={() => window.location.reload()}>Reload Page</button>
+          <button onClick={() => window.location.reload()}>
+            {IS_CHINESE ? '重新加载' : 'Reload Page'}
+          </button>
           <a
             href="https://github.com/yihong0618/running_page#map-tiles-customization"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Troubleshooting Guide
+            {IS_CHINESE ? '排障指南' : 'Troubleshooting Guide'}
           </a>
         </div>
       )}

--- a/src/components/RunTable/index.tsx
+++ b/src/components/RunTable/index.tsx
@@ -6,7 +6,11 @@ import {
   Activity,
   RunIds,
 } from '@/utils/utils';
-import { SHOW_ELEVATION_GAIN, type SportTypeFilter } from '@/utils/const';
+import {
+  IS_CHINESE,
+  SHOW_ELEVATION_GAIN,
+  type SportTypeFilter,
+} from '@/utils/const';
 import { DIST_UNIT } from '@/utils/utils';
 import {
   getPrimaryMetricLabel,
@@ -26,6 +30,11 @@ interface IRunTableProperties {
 }
 
 type SortFunc = (_a: Activity, _b: Activity) => number;
+
+const ELEVATION_COLUMN_TITLE = IS_CHINESE ? '爬升' : 'Elev';
+const HEART_RATE_COLUMN_TITLE = IS_CHINESE ? '心率' : 'BPM';
+const TIME_COLUMN_TITLE = IS_CHINESE ? '时长' : 'Time';
+const DATE_COLUMN_TITLE = IS_CHINESE ? '日期' : 'Date';
 
 const RunTable = ({
   runs,
@@ -61,7 +70,7 @@ const RunTable = ({
       compareNullableNumber(
         a.elevation_gain,
         b.elevation_gain,
-        sortFuncInfo === 'Elev'
+        sortFuncInfo === ELEVATION_COLUMN_TITLE
       );
     const sortPrimaryMetricFunc: SortFunc = (a, b) => {
       const aValue = getPrimaryMetricSortValue(a, sportType);
@@ -77,30 +86,30 @@ const RunTable = ({
       return compareNullableNumber(
         a.average_heartrate,
         b.average_heartrate,
-        sortFuncInfo === 'BPM'
+        sortFuncInfo === HEART_RATE_COLUMN_TITLE
       );
     };
     const sortRunTimeFunc: SortFunc = (a, b) => {
       const aTotalSeconds = convertMovingTime2Sec(a.moving_time);
       const bTotalSeconds = convertMovingTime2Sec(b.moving_time);
-      return sortFuncInfo === 'Time'
+      return sortFuncInfo === TIME_COLUMN_TITLE
         ? aTotalSeconds - bTotalSeconds
         : bTotalSeconds - aTotalSeconds;
     };
     const sortDateFuncClick =
-      sortFuncInfo === 'Date' ? sortDateFuncReverse : sortDateFunc;
+      sortFuncInfo === DATE_COLUMN_TITLE ? sortDateFuncReverse : sortDateFunc;
 
     const sortFuncMap = new Map([
       [DIST_UNIT, sortKMFunc],
-      ['Elev', sortElevationGainFunc],
+      [ELEVATION_COLUMN_TITLE, sortElevationGainFunc],
       [primaryMetricLabel, sortPrimaryMetricFunc],
-      ['BPM', sortBPMFunc],
-      ['Time', sortRunTimeFunc],
-      ['Date', sortDateFuncClick],
+      [HEART_RATE_COLUMN_TITLE, sortBPMFunc],
+      [TIME_COLUMN_TITLE, sortRunTimeFunc],
+      [DATE_COLUMN_TITLE, sortDateFuncClick],
     ]);
 
     if (!SHOW_ELEVATION_GAIN) {
-      sortFuncMap.delete('Elev');
+      sortFuncMap.delete(ELEVATION_COLUMN_TITLE);
     }
 
     return sortFuncMap;
@@ -124,7 +133,7 @@ const RunTable = ({
       <table className={styles.runTable} cellSpacing="0" cellPadding="0">
         <thead>
           <tr>
-            <th />
+            <th>{IS_CHINESE ? '活动' : 'Activity'}</th>
             {Array.from(sortFunctions.keys()).map((k) => (
               <th key={k} data-sort-key={k} onClick={handleClick}>
                 {k}

--- a/src/components/SVGStat/index.tsx
+++ b/src/components/SVGStat/index.tsx
@@ -2,7 +2,12 @@ import { lazy, Suspense, useEffect, useMemo } from 'react';
 import { totalStat } from '@assets/index';
 import { loadSvgComponent } from '@/utils/svgUtils';
 import { initSvgColorAdjustments } from '@/utils/colorUtils';
-import { SPORT_TYPE_OPTIONS, type SportTypeFilter } from '@/utils/const';
+import {
+  IS_CHINESE,
+  LOADING_TEXT,
+  SPORT_TYPE_OPTIONS,
+  type SportTypeFilter,
+} from '@/utils/const';
 
 const SVGStat = ({
   sportType = 'all',
@@ -34,6 +39,7 @@ const SVGStat = ({
       {onSportTypeChange && (
         <div className="mb-2 mt-4 flex justify-end">
           <select
+            aria-label={IS_CHINESE ? '运动类型' : 'Sport type'}
             className="rounded border border-gray-600 bg-transparent px-2 py-1 text-sm"
             value={sportType}
             onChange={(e) =>
@@ -48,7 +54,7 @@ const SVGStat = ({
           </select>
         </div>
       )}
-      <Suspense fallback={<div className="text-center">Loading...</div>}>
+      <Suspense fallback={<div className="text-center">{LOADING_TEXT}</div>}>
         <GithubSvg className="github-svg mt-4 h-auto w-full" />
         <GridSvg className="grid-svg mt-4 h-auto w-full" />
       </Suspense>

--- a/src/components/Stat/index.tsx
+++ b/src/components/Stat/index.tsx
@@ -16,10 +16,14 @@ const Stat = ({
   onClick,
 }: IStatProperties) => (
   <div className={`${className}`} onClick={onClick}>
-    <span className={`text-${citySize || 5}xl font-bold italic`}>
+    <span
+      className={`${citySize ? 'text-3xl' : 'text-2xl sm:text-3xl lg:text-5xl'} font-bold italic`}
+    >
       {intComma(value.toString())}
     </span>
-    <span className="text-lg font-semibold italic">{description}</span>
+    <span className="text-xs font-semibold italic sm:text-sm lg:text-lg">
+      {description}
+    </span>
   </div>
 );
 

--- a/src/components/YearStat/index.tsx
+++ b/src/components/YearStat/index.tsx
@@ -6,6 +6,7 @@ import { yearStats, githubYearStats } from '@assets/index';
 import { loadSvgComponent } from '@/utils/svgUtils';
 import {
   IS_CHINESE,
+  LOADING_TEXT,
   SHOW_ELEVATION_GAIN,
   type SportTypeFilter,
 } from '@/utils/const';
@@ -179,14 +180,25 @@ const YearStat = ({
     hasLowestElevation;
   return (
     <div className="cursor-pointer" onClick={() => onClick(year)}>
-      <section {...eventHandlers}>
-        <Stat value={year} description=" Journey" />
-        <Stat value={runs.length} description=" Activities" />
+      <section className="grid grid-cols-2 gap-x-4 lg:block" {...eventHandlers}>
+        <Stat
+          value={year === 'Total' && IS_CHINESE ? '全部' : year}
+          description={IS_CHINESE ? ' 概览' : ' Journey'}
+          className="col-span-2 w-full pb-2"
+        />
+        <Stat
+          value={runs.length}
+          description={IS_CHINESE ? ' 次活动' : ' Activities'}
+        />
         <Stat value={sumDistance} description={` ${DIST_UNIT}`} />
         {showElevationMetrics && (
           <Stat
             value={sumElevationGainStr}
-            description={` Elevation Gain (${ELEV_UNIT})`}
+            description={
+              IS_CHINESE
+                ? ` 海拔爬升 (${ELEV_UNIT})`
+                : ` Elevation Gain (${ELEV_UNIT})`
+            }
           />
         )}
         {showElevationMetrics && elevationLossCount > 0 && (
@@ -229,9 +241,15 @@ const YearStat = ({
             description={` ${avgSecondaryMetricLabel}`}
           />
         )}
-        <Stat value={`${streak} day`} description=" Streak" />
+        <Stat
+          value={IS_CHINESE ? `${streak} 天` : `${streak} day`}
+          description={IS_CHINESE ? ' 连续记录' : ' Streak'}
+        />
         {hasHeartRate && (
-          <Stat value={avgHeartRate} description=" Avg Heart Rate" />
+          <Stat
+            value={avgHeartRate}
+            description={IS_CHINESE ? ' 平均心率' : ' Avg Heart Rate'}
+          />
         )}
         {hasPower && (
           <Stat
@@ -273,12 +291,12 @@ const YearStat = ({
         )}
       </section>
       {year !== 'Total' && hovered && (
-        <Suspense fallback="loading...">
+        <Suspense fallback={LOADING_TEXT}>
           <YearSVG className="year-svg my-4 h-4/6 w-4/6 border-0 p-0" />
           <GithubYearSVG className="github-year-svg my-4 h-auto w-full border-0 p-0" />
         </Suspense>
       )}
-      <hr />
+      <hr className="my-4 lg:my-8" />
     </div>
   );
 };

--- a/src/components/YearsStat/index.tsx
+++ b/src/components/YearsStat/index.tsx
@@ -30,14 +30,14 @@ const YearsStat = ({
 
   // for short solution need to refactor
   return (
-    <div className="w-full pb-16 pr-16 lg:w-full lg:pr-16">
+    <div className="w-full pb-6 lg:pb-16 lg:pr-16">
       <section className="pb-0">
         <p className="leading-relaxed">
           {infoMessage}
           <br />
         </p>
       </section>
-      <hr />
+      <hr className="my-4 lg:my-8" />
       {yearsArrayUpdate.map((yearItem) => (
         <YearStat
           key={yearItem}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import { HelmetProvider } from 'react-helmet-async';
 import Index from './pages';
 import NotFound from './pages/404';
 import ReactGA from 'react-ga4';
@@ -37,8 +36,6 @@ const routes = createBrowserRouter(
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <HelmetProvider>
-      <RouterProvider router={routes} />
-    </HelmetProvider>
+    <RouterProvider router={routes} />
   </React.StrictMode>
 );

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,14 +1,15 @@
 import Layout from '@/components/Layout';
 import useSiteMetadata from '@/hooks/useSiteMetadata';
+import { IS_CHINESE } from '@/utils/const';
 
 const NotFoundPage = () => {
   const { siteUrl } = useSiteMetadata();
   return (
     <Layout>
       <h1 className="my-2.5 text-5xl font-bold italic">404</h1>
-      <p>This page doesn&#39;t exist.</p>
+      <p>{IS_CHINESE ? '页面不存在。' : "This page doesn't exist."}</p>
       <p className="text-gray-400">
-        If you wanna more message, you could visit{' '}
+        {IS_CHINESE ? '返回主页：' : 'Visit the home page: '}
         <a className="font-bold text-gray-400" href={siteUrl}>
           {siteUrl}
         </a>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { Helmet } from 'react-helmet-async';
 import Layout from '@/components/Layout';
 import LocationStat from '@/components/LocationStat';
 import RunMap from '@/components/RunMap';
@@ -25,7 +24,7 @@ import {
   titleForShow,
   RunIds,
 } from '@/utils/utils';
-import { useTheme, useThemeChangeCounter } from '@/hooks/useTheme';
+import { useThemeChangeCounter } from '@/hooks/useTheme';
 
 const Index = () => {
   const { siteTitle, siteUrl } = useSiteMetadata();
@@ -165,7 +164,9 @@ const Index = () => {
       }
       setCurrentFilter({ item, func });
       setRunIndex(-1);
-      setTitle(`${item} ${name} Activity Heatmap`);
+      setTitle(
+        IS_CHINESE ? `${item}活动轨迹` : `${item} ${name} Activity Heatmap`
+      );
       // Reset single run state when changing filters
       setSingleRunId(null);
       if (window.location.hash) {
@@ -389,18 +390,13 @@ const Index = () => {
     };
   }, [year, runs, locateActivity, thisYear]);
 
-  const { theme } = useTheme();
-
   return (
     <Layout>
-      <Helmet>
-        <html lang="en" data-theme={theme} />
-      </Helmet>
       <div className="w-full lg:w-1/3">
         <h1 className="my-12 mt-6 text-5xl font-extrabold italic">
           <a href={siteUrl}>{siteTitle}</a>
         </h1>
-        {(viewState.zoom ?? 0) <= 3 && IS_CHINESE ? (
+        {(viewState.zoom ?? 0) <= 3 ? (
           <LocationStat
             changeYear={changeYear}
             changeCity={changeCity}

--- a/src/pages/total.tsx
+++ b/src/pages/total.tsx
@@ -1,28 +1,18 @@
 import ActivityList from '@/components/ActivityList';
-import { Helmet } from 'react-helmet-async';
 import { useTheme } from '@/hooks/useTheme';
 import { useEffect } from 'react';
+import { IS_CHINESE } from '@/utils/const';
 
 const HomePage = () => {
-  // Use the theme hook to get the current theme
   const { theme } = useTheme();
 
-  // Apply theme changes to the document when theme changes
   useEffect(() => {
-    const htmlElement = document.documentElement;
-    // Set explicit theme attribute
-    htmlElement.setAttribute('data-theme', theme);
+    document.documentElement.lang = IS_CHINESE ? 'zh-CN' : 'en';
+    document.documentElement.setAttribute('data-theme', theme);
+    document.title = IS_CHINESE ? '运动汇总' : 'Activity Summary';
   }, [theme]);
 
-  return (
-    <>
-      <Helmet>
-        {/* Set HTML attributes including theme */}
-        <html lang="en" data-theme={theme} />
-      </Helmet>
-      <ActivityList />
-    </>
-  );
+  return <ActivityList />;
 };
 
 export default HomePage;

--- a/src/static/site-metadata.ts
+++ b/src/static/site-metadata.ts
@@ -1,3 +1,5 @@
+import { IS_CHINESE } from '@/utils/const';
+
 interface ISiteMetadataResult {
   siteTitle: string;
   siteUrl: string;
@@ -15,21 +17,23 @@ const getBasePath = () => {
 };
 
 const data: ISiteMetadataResult = {
-  siteTitle: 'Activity Page',
+  siteTitle: IS_CHINESE ? '运动记录' : 'Activity Page',
   siteUrl: 'https://run.treesir.pub',
   logo: 'https://avatars.githubusercontent.com/u/45552084?s=256&v=4',
-  description: 'Personal activity records and blog',
+  description: IS_CHINESE
+    ? '个人运动记录与博客'
+    : 'Personal activity records and blog',
   navLinks: [
     {
-      name: 'Summary',
+      name: IS_CHINESE ? '汇总' : 'Summary',
       url: `${getBasePath()}/summary`,
     },
     {
-      name: 'Blog',
+      name: IS_CHINESE ? '博客' : 'Blog',
       url: 'https://www.treesir.pub',
     },
     {
-      name: 'About',
+      name: IS_CHINESE ? '关于' : 'About',
       url: 'https://github.com/cdryzun',
     },
   ],

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,3 +1,5 @@
+import { getStoredLanguage } from '@/utils/language';
+
 // Constants
 const MAPBOX_TOKEN =
   // For security reasons, please avoid using the default public token provided by Mapbox as much as possible.
@@ -50,20 +52,24 @@ const SHOW_ELEVATION_GAIN = false;
 // richer title for the activity types (like garmin style)
 const RICH_TITLE = false;
 
-// IF you are outside China please make sure IS_CHINESE = false
-const IS_CHINESE = true;
+// Chinese is the default; the header language switch persists the preference.
+const IS_CHINESE = getStoredLanguage() === 'zh-CN';
 const USE_ANIMATION_FOR_GRID = false;
 const CHINESE_INFO_MESSAGE = (yearLength: number, year: string): string => {
-  const yearStr = year === 'Total' ? '所有' : ` ${year} `;
-  return `我用 App 记录自己运动 ${yearLength} 年了，下面列表展示的是${yearStr}的数据`;
+  const period = year === 'Total' ? '全部年份' : `${year} 年`;
+  return `我已用 App 记录运动 ${yearLength} 年，以下是${period}的运动数据。`;
 };
-const ENGLISH_INFO_MESSAGE = (yearLength: number, year: string): string =>
-  `Activity Journey with ${yearLength} Years, the table shows year ${year} data`;
+const ENGLISH_INFO_MESSAGE = (yearLength: number, year: string): string => {
+  const period = year === 'Total' ? 'all years' : year;
+  return `I have recorded activities for ${yearLength} years. The statistics below cover ${period}.`;
+};
 
-// English is not supported for location info messages yet
-const CHINESE_LOCATION_INFO_MESSAGE_FIRST =
-  '我运动过了一些地方，希望随着时间推移，地图点亮的地方越来越多';
-const CHINESE_LOCATION_INFO_MESSAGE_SECOND = '不要停下来，不要停下运动的脚步';
+const LOCATION_INFO_MESSAGE_FIRST = IS_CHINESE
+  ? '我的运动足迹分布在以下地区，点击城市或运动类型可筛选地图。'
+  : 'My activity footprint spans the regions below. Select a city or activity type to filter the map.';
+const LOCATION_INFO_MESSAGE_SECOND = IS_CHINESE
+  ? '继续记录，看看下一次会点亮哪里。'
+  : 'Keep logging activities to see where the next one takes you.';
 
 const INFO_MESSAGE = IS_CHINESE ? CHINESE_INFO_MESSAGE : ENGLISH_INFO_MESSAGE;
 const FULL_MARATHON_RUN_TITLE = IS_CHINESE ? '全程马拉松' : 'Full Marathon';
@@ -93,11 +99,11 @@ const TOTAL_ELEVATION_GAIN_TITLE = IS_CHINESE
   ? '总海拔爬升'
   : 'Total Elevation Gain';
 const AVERAGE_HEART_RATE_TITLE = IS_CHINESE ? '平均心率' : 'Average Heart Rate';
-const YEARLY_TITLE = IS_CHINESE ? 'Year' : 'Yearly';
-const MONTHLY_TITLE = IS_CHINESE ? 'Month' : 'Monthly';
-const WEEKLY_TITLE = IS_CHINESE ? 'Week' : 'Weekly';
-const DAILY_TITLE = IS_CHINESE ? 'Day' : 'Daily';
-const LOCATION_TITLE = IS_CHINESE ? 'Location' : 'Location';
+const YEARLY_TITLE = IS_CHINESE ? '按年' : 'Yearly';
+const MONTHLY_TITLE = IS_CHINESE ? '按月' : 'Monthly';
+const WEEKLY_TITLE = IS_CHINESE ? '按周' : 'Weekly';
+const DAILY_TITLE = IS_CHINESE ? '按日' : 'Daily';
+const LOCATION_TITLE = IS_CHINESE ? '地点' : 'Location';
 const HOME_PAGE_TITLE = IS_CHINESE ? '首页' : 'Home';
 
 const LOADING_TEXT = IS_CHINESE ? '加载中...' : 'Loading...';
@@ -157,8 +163,8 @@ const ACTIVITY_TOTAL = {
 export {
   USE_GOOGLE_ANALYTICS,
   GOOGLE_ANALYTICS_TRACKING_ID,
-  CHINESE_LOCATION_INFO_MESSAGE_FIRST,
-  CHINESE_LOCATION_INFO_MESSAGE_SECOND,
+  LOCATION_INFO_MESSAGE_FIRST,
+  LOCATION_INFO_MESSAGE_SECOND,
   MAPBOX_TOKEN,
   MUNICIPALITY_CITIES_ARR,
   MAP_LAYER_LIST,

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -1,0 +1,26 @@
+export type Language = 'zh-CN' | 'en';
+
+export const DEFAULT_LANGUAGE: Language = 'zh-CN';
+export const LANGUAGE_STORAGE_KEY = 'language';
+
+export const resolveLanguage = (value: string | null): Language =>
+  value === 'en' ? 'en' : DEFAULT_LANGUAGE;
+
+export const getStoredLanguage = (): Language => {
+  if (typeof window === 'undefined') return DEFAULT_LANGUAGE;
+
+  try {
+    return resolveLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY));
+  } catch {
+    return DEFAULT_LANGUAGE;
+  }
+};
+
+export const persistLanguage = (language: Language): boolean => {
+  try {
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/utils/sportMetrics.ts
+++ b/src/utils/sportMetrics.ts
@@ -23,10 +23,10 @@ const metricsMode: SportMetricsMode =
 const METRIC_LABELS = {
   pace: IS_CHINESE ? '配速' : 'Pace',
   speed: IS_CHINESE ? '速度' : 'Speed',
-  metric: IS_CHINESE ? '指标' : 'Metric',
+  metric: IS_CHINESE ? '速度' : 'Speed',
   avgPace: IS_CHINESE ? '平均配速' : 'Avg Pace',
   avgSpeed: IS_CHINESE ? '平均速度' : 'Avg Speed',
-  avgMetric: IS_CHINESE ? '平均指标' : 'Avg Metric',
+  avgMetric: IS_CHINESE ? '平均速度' : 'Avg Speed',
 };
 
 const isValidSpeed = (speed?: number | null): speed is number =>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,6 +5,7 @@ import { RPGeometry } from '@/static/run_countries';
 import { chinaCities } from '@/static/city';
 import {
   MAIN_COLOR,
+  IS_CHINESE,
   MUNICIPALITY_CITIES_ARR,
   NEED_FIX_MAP,
   RUN_TITLES,
@@ -118,13 +119,14 @@ export { isIndoorActivity };
 const titleForShow = (run: Activity): string => {
   const date = run.start_date_local.slice(0, 11);
   const distance = (run.distance / M_TO_DIST).toFixed(2);
-  let name = run.name || getActivitySport(run) || 'Activity';
-  if (!run.name) {
-    name = getActivitySport(run) || 'Activity';
-  }
-  return `${name} ${date} ${distance} ${DIST_UNIT} ${
-    !run.summary_polyline ? '(No map data for this activity)' : ''
-  }`;
+  const fallbackName = IS_CHINESE ? '运动' : 'Activity';
+  const name = run.name || getActivitySport(run) || fallbackName;
+  const noMapText = !run.summary_polyline
+    ? IS_CHINESE
+      ? '（此活动无轨迹数据）'
+      : '(No map data for this activity)'
+    : '';
+  return `${name} ${date} ${distance} ${DIST_UNIT} ${noMapText}`.trim();
 };
 
 const formatPace = (d: number): string => {

--- a/tests/language.test.mjs
+++ b/tests/language.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { URL } from 'node:url';
+import ts from 'typescript';
+
+const source = await readFile(
+  new URL('../src/utils/language.ts', import.meta.url),
+  'utf8'
+);
+const { outputText } = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+});
+const language = await import(
+  `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
+);
+
+test('resolveLanguage defaults to Chinese and accepts English', () => {
+  assert.equal(language.resolveLanguage(null), 'zh-CN');
+  assert.equal(language.resolveLanguage('unsupported'), 'zh-CN');
+  assert.equal(language.resolveLanguage('zh-CN'), 'zh-CN');
+  assert.equal(language.resolveLanguage('en'), 'en');
+});
+
+test('stored language is persisted and storage failures are safe', () => {
+  const originalWindow = globalThis.window;
+  const values = new Map();
+
+  try {
+    globalThis.window = {
+      localStorage: {
+        getItem: (key) => values.get(key) ?? null,
+        setItem: (key, value) => values.set(key, value),
+      },
+    };
+
+    assert.equal(language.persistLanguage('en'), true);
+    assert.equal(language.getStoredLanguage(), 'en');
+
+    globalThis.window.localStorage.getItem = () => {
+      throw new Error('storage unavailable');
+    };
+    globalThis.window.localStorage.setItem = () => {
+      throw new Error('storage unavailable');
+    };
+
+    assert.equal(language.getStoredLanguage(), 'zh-CN');
+    assert.equal(language.persistLanguage('en'), false);
+  } finally {
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  }
+});

--- a/tests/test_deployment_config.py
+++ b/tests/test_deployment_config.py
@@ -20,6 +20,8 @@ ROOT = Path(__file__).resolve().parents[1]
 # Files read by multiple test cases, resolved once.
 ESA_JSONC = ROOT / "esa.jsonc"
 ESA_WORKFLOW = ROOT / ".github" / "workflows" / "esa_deploy.yml"
+DATA_SYNC_WORKFLOW = ROOT / ".github" / "workflows" / "run_data_sync.yml"
+DOCKERFILE = ROOT / "Dockerfile"
 VITE_CONFIG = ROOT / "vite.config.ts"
 PACKAGE_JSON = ROOT / "package.json"
 PNPM_LOCK = ROOT / "pnpm-lock.yaml"
@@ -78,6 +80,31 @@ class EsaConfigTest(unittest.TestCase):
             assets.get("notFoundStrategy"),
             "singlePageApplication",
             "Removing notFoundStrategy breaks SPA deep-link refresh",
+        )
+
+
+class DataSyncConfigTest(unittest.TestCase):
+    """Guard personal data-generation settings used by the sync workflow."""
+
+    def test_month_of_life_birth_month(self):
+        content = DATA_SYNC_WORKFLOW.read_text(encoding="utf-8")
+        self.assertRegex(
+            content,
+            r"(?m)^\s*BIRTHDAY_MONTH:\s*1999-10\s*(?:#.*)?$",
+            "Month-of-life posters must use the configured 1999-10 birth month",
+        )
+
+    def test_docker_month_of_life_birth_month(self):
+        content = DOCKERFILE.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "--birth 1989-03",
+            content,
+            "Docker image generation must not use the previous birth month",
+        )
+        self.assertEqual(
+            content.count("--birth 1999-10"),
+            2,
+            "Both Docker month-of-life commands must use 1999-10",
         )
 
 


### PR DESCRIPTION
## Summary

- add persistent Chinese/English switching on the home and summary pages
- localize statistics, navigation, map controls, table headers, metadata, and empty/error states
- improve mobile spacing and responsive statistic layout without changing activity data
- update month-of-life birth month to `1999-10` in the sync workflow and Docker generation commands
- add language persistence unit tests and birth-month regression tests

## Verification

- `npm run check`
- `npm run lint`
- `npm run test:unit` (2 passed)
- `npm run build`
- `python -m unittest discover -s tests` (63 passed)
- pre-push `pytest -q` (63 passed)
- bilingual browser regression at desktop and 390 px mobile widths
- Chinese to English to Chinese switching verified on `/` and `/summary`
- no horizontal overflow or clipped controls detected
