### PR TITLE
fix: prevent activity icons from crowding data

### DIFF
--- a/src/components/RunTable/RunRow.tsx
+++ b/src/components/RunTable/RunRow.tsx
@@ -26,12 +26,21 @@ interface IRunRowProperties {
   setRunIndex: (_ndex: number) => void;
 }
 
+type RowMetaKey = 'gain' | 'loss' | 'power' | 'cadence';
+
 interface RowMetaItem {
-  key: string;
+  key: RowMetaKey;
   icon: string;
   value: string;
   estimated?: boolean;
 }
+
+const ROW_META_LABELS: Record<RowMetaKey, string> = {
+  gain: IS_CHINESE ? '爬升' : 'Elevation gain',
+  loss: IS_CHINESE ? '下降' : 'Elevation loss',
+  power: IS_CHINESE ? '功率' : 'Power',
+  cadence: IS_CHINESE ? '踏频' : 'Cadence',
+};
 
 const RunRow = ({
   elementIndex,
@@ -88,7 +97,7 @@ const RunRow = ({
     ? `${(run.average_cadence as number).toFixed(0)}${cadenceUnit}`
     : '--';
   const addMeta = (
-    key: string,
+    key: RowMetaKey,
     icon: string,
     value: string,
     estimated = false
@@ -97,8 +106,8 @@ const RunRow = ({
   if (normalizedType === 'cycling') {
     addMeta('gain', '↑', elevationGainText, gainEstimated);
     addMeta('loss', '↓', elevationLossText, lossEstimated);
-    addMeta('power', '⚡', powerText);
-    addMeta('cadence', '⟳', cadenceText);
+    addMeta('power', '⚡︎', powerText);
+    addMeta('cadence', '↻', cadenceText);
   } else if (normalizedType === 'hiking') {
     addMeta('gain', '↑', elevationGainText, gainEstimated);
     addMeta('loss', '↓', elevationLossText, lossEstimated);
@@ -110,10 +119,10 @@ const RunRow = ({
       addMeta('loss', '↓', elevationLossText);
     }
     if (hasPower) {
-      addMeta('power', '⚡', powerText);
+      addMeta('power', '⚡︎', powerText);
     }
     if (hasCadence) {
-      addMeta('cadence', '⟳', cadenceText);
+      addMeta('cadence', '↻', cadenceText);
     }
   }
   const handleClick = () => {
@@ -133,27 +142,35 @@ const RunRow = ({
       onClick={handleClick}
     >
       <td>
-        {titleForRun(run)}
+        <span className={styles.activityTitle}>{titleForRun(run)}</span>
         {rowMetaItems.length > 0 && (
           <span className={styles.rowMeta}>
-            {rowMetaItems.map((item, idx) => (
-              <span
-                key={`${item.key}-${idx}`}
-                className={`${styles.metaSlot} ${
-                  item.estimated ? styles.metaSlotEstimated : ''
-                }`}
-                title={
-                  item.estimated
-                    ? IS_CHINESE
-                      ? '估算值（原始上升/下降缺失）'
-                      : 'Estimated (source ascent/descent missing)'
-                    : undefined
-                }
-              >
-                <span className={styles.metaIcon}>{item.icon}</span>
-                <span className={styles.metaValue}>{item.value}</span>
-              </span>
-            ))}
+            {rowMetaItems.map((item) => {
+              const label = ROW_META_LABELS[item.key];
+              const accessibleText = item.estimated
+                ? IS_CHINESE
+                  ? `${label}：${item.value}，估算值（原始上升/下降缺失）`
+                  : `${label}: ${item.value}, estimated because source ascent/descent is missing`
+                : IS_CHINESE
+                  ? `${label}：${item.value}`
+                  : `${label}: ${item.value}`;
+
+              return (
+                <span
+                  key={item.key}
+                  className={`${styles.metaSlot} ${
+                    item.estimated ? styles.metaSlotEstimated : ''
+                  }`}
+                  title={accessibleText}
+                  aria-label={accessibleText}
+                >
+                  <span className={styles.metaIcon} aria-hidden="true">
+                    {item.icon}
+                  </span>
+                  <span className={styles.metaValue}>{item.value}</span>
+                </span>
+              );
+            })}
           </span>
         )}
       </td>

--- a/src/components/RunTable/style.module.css
+++ b/src/components/RunTable/style.module.css
@@ -18,7 +18,10 @@
 
   .runTable th:first-child,
   .runTable td:first-child {
-    min-width: 100px;
+    width: 15rem;
+    min-width: 15rem;
+    max-width: 15rem;
+    white-space: normal;
   }
 
   .runTable th:last-child,
@@ -109,14 +112,21 @@
   opacity: 0.8;
 }
 
+.activityTitle {
+  display: block;
+  line-height: 1.25;
+}
+
 .rowMeta {
-  margin-left: 0.35rem;
+  margin: 0.25rem 0 0;
   font-size: 0.72rem;
   opacity: 0.86;
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 0.18rem;
-  vertical-align: middle;
+  gap: 0.3rem 0.7rem;
+  line-height: 1.2;
+  white-space: normal;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-mono);
 }
@@ -124,10 +134,9 @@
 .metaSlot {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 0.1rem;
-  min-width: 8ch;
-  line-height: 1;
+  gap: 0.2rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .metaSlotEstimated {
@@ -135,14 +144,20 @@
 }
 
 .metaIcon {
-  width: 0.85rem;
+  width: 1rem;
   text-align: center;
-  flex: 0 0 0.85rem;
+  flex: 0 0 1rem;
+  line-height: 1;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI Symbol',
+    sans-serif;
 }
 
 .metaValue {
-  font-variant-numeric: tabular-nums;
   display: inline-block;
-  min-width: 5.8ch;
   text-align: left;
+  font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Summary

- move elevation, descent, power, and cadence metadata below the activity title
- replace font-dependent glyphs with stable text-presentation symbols
- remove fixed character widths so icon/value groups wrap without collision
- constrain the mobile activity column while keeping horizontal scrolling inside the table
- add localized metric tooltips and accessible labels

## Verification

- `npm run check`
- `npm run lint`
- `npm run test:unit` (2 passed)
- `npm run build`
- `python -m unittest discover -s tests` (63 passed)
- pre-push `pytest -q` (63 passed)
- browser geometry regression on desktop and 390 px mobile
- Chinese and English icon/value bounds verified with no overlap
- metadata verified below activity titles
- document width unchanged; table overflow remains container-scoped
