### PR TITLE
fix: restore compact activity table

### DIFF
--- a/src/components/RunTable/RunRow.tsx
+++ b/src/components/RunTable/RunRow.tsx
@@ -26,21 +26,12 @@ interface IRunRowProperties {
   setRunIndex: (_ndex: number) => void;
 }
 
-type RowMetaKey = 'gain' | 'loss' | 'power' | 'cadence';
-
 interface RowMetaItem {
-  key: RowMetaKey;
+  key: string;
   icon: string;
   value: string;
   estimated?: boolean;
 }
-
-const ROW_META_LABELS: Record<RowMetaKey, string> = {
-  gain: IS_CHINESE ? '爬升' : 'Elevation gain',
-  loss: IS_CHINESE ? '下降' : 'Elevation loss',
-  power: IS_CHINESE ? '功率' : 'Power',
-  cadence: IS_CHINESE ? '踏频' : 'Cadence',
-};
 
 const RunRow = ({
   elementIndex,
@@ -97,7 +88,7 @@ const RunRow = ({
     ? `${(run.average_cadence as number).toFixed(0)}${cadenceUnit}`
     : '--';
   const addMeta = (
-    key: RowMetaKey,
+    key: string,
     icon: string,
     value: string,
     estimated = false
@@ -106,8 +97,8 @@ const RunRow = ({
   if (normalizedType === 'cycling') {
     addMeta('gain', '↑', elevationGainText, gainEstimated);
     addMeta('loss', '↓', elevationLossText, lossEstimated);
-    addMeta('power', '⚡︎', powerText);
-    addMeta('cadence', '↻', cadenceText);
+    addMeta('power', '⚡', powerText);
+    addMeta('cadence', '⟳', cadenceText);
   } else if (normalizedType === 'hiking') {
     addMeta('gain', '↑', elevationGainText, gainEstimated);
     addMeta('loss', '↓', elevationLossText, lossEstimated);
@@ -119,10 +110,10 @@ const RunRow = ({
       addMeta('loss', '↓', elevationLossText);
     }
     if (hasPower) {
-      addMeta('power', '⚡︎', powerText);
+      addMeta('power', '⚡', powerText);
     }
     if (hasCadence) {
-      addMeta('cadence', '↻', cadenceText);
+      addMeta('cadence', '⟳', cadenceText);
     }
   }
   const handleClick = () => {
@@ -142,35 +133,27 @@ const RunRow = ({
       onClick={handleClick}
     >
       <td>
-        <span className={styles.activityTitle}>{titleForRun(run)}</span>
+        {titleForRun(run)}
         {rowMetaItems.length > 0 && (
           <span className={styles.rowMeta}>
-            {rowMetaItems.map((item) => {
-              const label = ROW_META_LABELS[item.key];
-              const accessibleText = item.estimated
-                ? IS_CHINESE
-                  ? `${label}：${item.value}，估算值（原始上升/下降缺失）`
-                  : `${label}: ${item.value}, estimated because source ascent/descent is missing`
-                : IS_CHINESE
-                  ? `${label}：${item.value}`
-                  : `${label}: ${item.value}`;
-
-              return (
-                <span
-                  key={item.key}
-                  className={`${styles.metaSlot} ${
-                    item.estimated ? styles.metaSlotEstimated : ''
-                  }`}
-                  title={accessibleText}
-                  aria-label={accessibleText}
-                >
-                  <span className={styles.metaIcon} aria-hidden="true">
-                    {item.icon}
-                  </span>
-                  <span className={styles.metaValue}>{item.value}</span>
-                </span>
-              );
-            })}
+            {rowMetaItems.map((item, idx) => (
+              <span
+                key={`${item.key}-${idx}`}
+                className={`${styles.metaSlot} ${
+                  item.estimated ? styles.metaSlotEstimated : ''
+                }`}
+                title={
+                  item.estimated
+                    ? IS_CHINESE
+                      ? '估算值（原始上升/下降缺失）'
+                      : 'Estimated (source ascent/descent missing)'
+                    : undefined
+                }
+              >
+                <span className={styles.metaIcon}>{item.icon}</span>
+                <span className={styles.metaValue}>{item.value}</span>
+              </span>
+            ))}
           </span>
         )}
       </td>

--- a/src/components/RunTable/style.module.css
+++ b/src/components/RunTable/style.module.css
@@ -18,10 +18,7 @@
 
   .runTable th:first-child,
   .runTable td:first-child {
-    width: 15rem;
-    min-width: 15rem;
-    max-width: 15rem;
-    white-space: normal;
+    min-width: 100px;
   }
 
   .runTable th:last-child,
@@ -112,21 +109,14 @@
   opacity: 0.8;
 }
 
-.activityTitle {
-  display: block;
-  line-height: 1.25;
-}
-
 .rowMeta {
-  margin: 0.25rem 0 0;
+  margin-left: 0.35rem;
   font-size: 0.72rem;
   opacity: 0.86;
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
   align-items: center;
-  gap: 0.3rem 0.7rem;
-  line-height: 1.2;
-  white-space: normal;
+  gap: 0.18rem;
+  vertical-align: middle;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-mono);
 }
@@ -134,9 +124,10 @@
 .metaSlot {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
-  line-height: 1.2;
-  white-space: nowrap;
+  justify-content: flex-start;
+  gap: 0.1rem;
+  min-width: 8ch;
+  line-height: 1;
 }
 
 .metaSlotEstimated {
@@ -144,20 +135,14 @@
 }
 
 .metaIcon {
-  width: 1rem;
+  width: 0.85rem;
   text-align: center;
-  flex: 0 0 1rem;
-  line-height: 1;
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI Symbol',
-    sans-serif;
+  flex: 0 0 0.85rem;
 }
 
 .metaValue {
-  display: inline-block;
-  text-align: left;
   font-variant-numeric: tabular-nums;
+  display: inline-block;
+  min-width: 5.8ch;
+  text-align: left;
 }


### PR DESCRIPTION
## Summary

- revert the unintended activity-table redesign from PR #22
- restore the original compact single-line activity rows
- restore the original first-column sizing and metadata glyph layout
- leave synced activity data and the left statistics panel unchanged

## Verification

- both table files exactly match pre-PR #22 commit `5737b41c`
- `npm run check`
- `npm run lint`
- `npm run test:unit` (2 passed)
- `npm run build`
- `python -m unittest discover -s tests` (63 passed)
- pre-push `pytest -q` (63 passed)
- browser regression at 2560 px: 40 px rows, inline metadata, no two-line wrapper
