### PR TITLE
fix: align year chart visible edges

### DIFF
--- a/src/components/YearCharts/index.test.tsx
+++ b/src/components/YearCharts/index.test.tsx
@@ -44,6 +44,9 @@ describe('YearCharts', () => {
 
     const slot = screen.getByRole('region', { name: '年度图表' });
     expect(slot).toHaveClass(
+      'flex',
+      'flex-col',
+      'gap-0',
       'h-72',
       'lg:h-[32rem]',
       'overflow-hidden',
@@ -57,8 +60,15 @@ describe('YearCharts', () => {
 
     expect(yearChart.parentElement).toBe(slot);
     expect(githubYearChart.parentElement).toBe(slot);
-    expect(yearChart).toHaveClass('block', 'h-2/3', 'w-full');
-    expect(githubYearChart).toHaveClass('block', 'h-1/3', 'w-full');
+    expect(yearChart).toHaveClass('block', 'min-h-0', 'flex-[200]', 'w-full');
+    expect(githubYearChart).toHaveClass(
+      'block',
+      'min-h-0',
+      'flex-[98]',
+      'w-full'
+    );
+    expect(yearChart).not.toHaveClass('h-2/3');
+    expect(githubYearChart).not.toHaveClass('h-1/3');
     expect(yearChart).toHaveAttribute('preserveAspectRatio', 'xMinYMid meet');
     expect(githubYearChart).toHaveAttribute(
       'preserveAspectRatio',

--- a/src/components/YearCharts/index.tsx
+++ b/src/components/YearCharts/index.tsx
@@ -30,7 +30,7 @@ const YearCharts: FC<YearChartsProps> = ({ year }) => {
 
   return (
     <div
-      className="mb-4 h-72 overflow-hidden lg:mb-8 lg:h-[32rem]"
+      className="mb-4 flex h-72 flex-col gap-0 overflow-hidden lg:mb-8 lg:h-[32rem]"
       role="region"
       aria-label={IS_CHINESE ? '年度图表' : 'Year charts'}
     >
@@ -42,11 +42,11 @@ const YearCharts: FC<YearChartsProps> = ({ year }) => {
         }
       >
         <YearSVG
-          className="year-svg block h-2/3 w-full border-0 p-0"
+          className="year-svg block min-h-0 w-full flex-[200] border-0 p-0"
           preserveAspectRatio="xMinYMid meet"
         />
         <GithubYearSVG
-          className="github-year-svg block h-1/3 w-full border-0 p-0"
+          className="github-year-svg block min-h-0 w-full flex-[98] border-0 p-0"
           preserveAspectRatio="xMinYMid meet"
         />
       </Suspense>


### PR DESCRIPTION
## Summary

- distribute the fixed chart slot using the SVG viewBox height ratio (200:98)
- align the visible right edges of the circular and heatmap charts
- preserve left alignment, fixed slot height, and rerender stability

## Verification

- TDD regression test
- visible right-edge delta reduced from 6.97px to 0.003px
- desktop/mobile zh-CN and English browser regression
- 67 Python tests, 2 Node tests, 8 Vitest tests
- ESLint, Prettier, Node 20, and Vite production build