### PR TITLE
feat: add sport-specific distance thresholds

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -254,12 +254,12 @@ jobs:
           ATHLETE: ${{ env.ATHLETE }}
           MIN_GRID_DISTANCE: ${{ env.MIN_GRID_DISTANCE }}
         run: |
-          python run_page/gen_svg.py --from-db --title "$TITLE" --type github --github-style "align-firstday" --athlete "$ATHLETE" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python run_page/gen_svg.py --from-db --title "$TITLE_GRID" --type grid --athlete "$ATHLETE" --output assets/grid.svg --special-color yellow --special-color2 red --special-distance 20 --special-distance2 40 --use-localtime --min-distance "$MIN_GRID_DISTANCE"
-          python run_page/gen_svg.py --from-db --type circular --use-localtime
-          python run_page/gen_svg.py --from-db --type circular --language zh_CN --output-suffix _zh --use-localtime
-          python run_page/gen_svg.py --from-db --type github --generate-all-years --github-style "align-firstday" --athlete "$ATHLETE" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
-          python run_page/gen_svg.py --from-db --type github --generate-all-years --language zh_CN --output-suffix _zh --github-style "align-firstday" --athlete "$ATHLETE" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python run_page/gen_svg.py --from-db --title "$TITLE" --type github --github-style "align-firstday" --athlete "$ATHLETE" --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python run_page/gen_svg.py --from-db --title "$TITLE_GRID" --type grid --athlete "$ATHLETE" --output assets/grid.svg --special-color yellow --special-color2 red --use-localtime --min-distance "$MIN_GRID_DISTANCE"
+          python run_page/gen_svg.py --from-db --type circular --special-color yellow --special-color2 red --use-localtime
+          python run_page/gen_svg.py --from-db --type circular --language zh_CN --output-suffix _zh --special-color yellow --special-color2 red --use-localtime
+          python run_page/gen_svg.py --from-db --type github --generate-all-years --github-style "align-firstday" --athlete "$ATHLETE" --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
+          python run_page/gen_svg.py --from-db --type github --generate-all-years --language zh_CN --output-suffix _zh --github-style "align-firstday" --athlete "$ATHLETE" --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
 
         # if you want use the style:the start day of each year always aligns with Monday. please use the following script:
         # python run_page/gen_svg.py --from-db --title "${{ env.TITLE }}" --type github --github-style "align-monday" --athlete "${{ env.ATHLETE }}" --special-distance 10 --special-distance2 20 --special-color yellow --special-color2 red --output assets/github.svg --use-localtime --min-distance 0.5
@@ -280,7 +280,7 @@ jobs:
       - name: Make year summary
         if: env.GENERATE_MONTH_OF_LIFE == 'true'
         run: |
-          python run_page/gen_svg.py --from-db --type year_summary --output assets/year_summary.svg --athlete "${{ env.ATHLETE }}"
+          python run_page/gen_svg.py --from-db --type year_summary --output assets/year_summary.svg --athlete "${{ env.ATHLETE }}" --special-color yellow --special-color2 red
 
       - name: Save data to parqent
         if: env.SAVE_TO_PARQENT == 'true'

--- a/run_page/gen_svg.py
+++ b/run_page/gen_svg.py
@@ -159,16 +159,16 @@ def main():
         dest="special_distance",
         metavar="DISTANCE",
         type=float,
-        default=10.0,
-        help="Special Distance1 by km and color with the special_color",
+        default=None,
+        help="Override the yellow distance for every sport; requires --special-distance2.",
     )
     args_parser.add_argument(
         "--special-distance2",
         dest="special_distance2",
         metavar="DISTANCE",
         type=float,
-        default=20.0,
-        help="Special Distance2 by km and corlor with the special_color2",
+        default=None,
+        help="Override the red distance for every sport; requires --special-distance.",
     )
     args_parser.add_argument(
         "--min-distance",
@@ -223,6 +223,10 @@ def main():
     args = args_parser.parse_args()
     if not re.fullmatch(r"[A-Za-z0-9_-]*", args.output_suffix):
         raise ParameterError(f"Bad output suffix: {args.output_suffix}")
+    if (args.special_distance is None) != (args.special_distance2 is None):
+        raise ParameterError(
+            "--special-distance and --special-distance2 must be provided together"
+        )
 
     for _, drawer in drawers.items():
         drawer.fetch_args(args)
@@ -271,10 +275,12 @@ def main():
     else:
         p.title = p.trans("MY TRACKS")
 
-    p.special_distance = {
-        "special_distance": args.special_distance,
-        "special_distance2": args.special_distance2,
-    }
+    p.use_sport_specific_distances = args.special_distance is None
+    if not p.use_sport_specific_distances:
+        p.special_distance = {
+            "special_distance": args.special_distance,
+            "special_distance2": args.special_distance2,
+        }
 
     p.colors = {
         "background": args.background_color,

--- a/run_page/gpxtrackposter/circular_drawer.py
+++ b/run_page/gpxtrackposter/circular_drawer.py
@@ -228,9 +228,16 @@ class CircularDrawer(TracksDrawer):
         rr: ValueRange,
         center: XY,
     ):
-        length = sum([t.length for t in tracks])
-        has_special = len([t for t in tracks if t.special]) > 0
-        color = self.color(self.poster.length_range_by_date, length, has_special)
+        length = sum(t.length for t in tracks)
+        grade = self.poster.day_grade(tracks)
+        if grade == 2:
+            color = self.poster.colors.get("special2") or self.poster.colors.get(
+                "special"
+            )
+        elif grade == 1 or any(track.special for track in tracks):
+            color = self.poster.colors["special"]
+        else:
+            color = self.color(self.poster.length_range_by_date, length, False)
         r1 = rr.lower()
         r2 = (
             rr.lower()

--- a/run_page/gpxtrackposter/github_drawer.py
+++ b/run_page/gpxtrackposter/github_drawer.py
@@ -145,17 +145,18 @@ class GithubDrawer(TracksDrawer):
                     date_title = str(github_rect_day)
                     if date_title in self.poster.tracks_by_date:
                         tracks = self.poster.tracks_by_date[date_title]
-                        length = sum([t.length for t in tracks])
-                        distance1 = self.poster.special_distance["special_distance"]
-                        distance2 = self.poster.special_distance["special_distance2"]
-                        has_special = distance1 < self.poster.m2u(length) < distance2
-                        color = self.color(
-                            self.poster.length_range_by_date, length, has_special
-                        )
-                        if self.poster.m2u(length) >= distance2:
+                        length = sum(t.length for t in tracks)
+                        grade = self.poster.day_grade(tracks)
+                        if grade == 2:
                             color = self.poster.colors.get(
                                 "special2"
                             ) or self.poster.colors.get("special")
+                        elif grade == 1:
+                            color = self.poster.colors["special"]
+                        else:
+                            color = self.color(
+                                self.poster.length_range_by_date, length, False
+                            )
                         str_length = format_float(self.poster.m2u(length))
                         date_title = f"{date_title} {str_length} {self.poster.u()}"
 

--- a/run_page/gpxtrackposter/grid_drawer.py
+++ b/run_page/gpxtrackposter/grid_drawer.py
@@ -53,20 +53,20 @@ class GridDrawer(TracksDrawer):
             )
 
     def _draw_track(self, dr: svgwrite.Drawing, tr: Track, size: XY, offset: XY):
-        color = self.color(self.poster.length_range, tr.length, tr.special)
+        grade = self.poster.grade_track(tr)
+        if grade == 2:
+            color = self.poster.colors.get("special2") or self.poster.colors.get(
+                "special"
+            )
+        elif grade == 1 or tr.special:
+            color = self.poster.colors["special"]
+        else:
+            color = self.color(self.poster.length_range_by_date, tr.length, False)
 
         str_length = format_float(self.poster.m2u(tr.length))
 
         date_title = f"{str(tr.start_time_local)[:10]} {str_length}{self.poster.u()}"
         for line in project(tr.bbox(), size, offset, tr.polylines):
-            distance1 = self.poster.special_distance["special_distance"]
-            distance2 = self.poster.special_distance["special_distance2"]
-            has_special = distance1 < self.poster.m2u(tr.length) < distance2
-            color = self.color(self.poster.length_range_by_date, tr.length, has_special)
-            if self.poster.m2u(tr.length) >= distance2:
-                color = self.poster.colors.get("special2") or self.poster.colors.get(
-                    "special"
-                )
             is_indoor = getattr(tr, "subtype", None) == "indoor"
             polyline = dr.polyline(
                 points=line,

--- a/run_page/gpxtrackposter/month_of_life_drawer.py
+++ b/run_page/gpxtrackposter/month_of_life_drawer.py
@@ -59,15 +59,15 @@ class MonthOfLifeDrawer(TracksDrawer):
         for idx in range(total_months):
             y = self.birth_year + (self.birth_month - 1 + idx) // 12
             m = (self.birth_month - 1 + idx) % 12 + 1
-            # sum distances for this month
-            dist = 0
-            for tr in self.poster.tracks:
-                dt = tr.start_time_local
-                if dt.year == y and dt.month == m:
-                    dist += tr.length
-            month_distances.append((y, m, dist))
+            month_tracks = []
+            for track in self.poster.tracks:
+                date = track.start_time_local
+                if date.year == y and date.month == m:
+                    month_tracks.append(track)
+            distance = sum(track.length for track in month_tracks)
+            month_distances.append((y, m, distance, month_tracks))
         # draw circles
-        for idx, (y, m, dist) in enumerate(month_distances):
+        for idx, (y, m, dist, month_tracks) in enumerate(month_distances):
             x_idx = idx % cols
             y_idx = idx // cols
             cx = offset.x + spacing_x * x_idx + spacing_x / 2
@@ -81,19 +81,16 @@ class MonthOfLifeDrawer(TracksDrawer):
             age = (y - self.birth_year) + ((m - self.birth_month) / 12)
             title = f"{y}-{m:02d} ({int(age)} years old)"
             if dist > 0:
-                # Set color based on special distance ranges and generate gradients or use special colors
-                sd1 = self.poster.special_distance["special_distance"]
-                sd2 = self.poster.special_distance["special_distance2"]
-                dist_units = self.poster.m2u(dist)
-                if sd1 < dist_units < sd2:
-                    color = self.color(self.poster.length_range_by_date, dist, True)
-                elif dist_units >= sd2:
+                grade = self.poster.day_grade(month_tracks)
+                if grade == 2:
                     color = self.poster.colors.get(
                         "special2"
                     ) or self.poster.colors.get("special")
+                elif grade == 1:
+                    color = self.poster.colors["special"]
                 else:
                     color = self.color(self.poster.length_range_by_date, dist, False)
-                val = format_float(dist_units)
+                val = format_float(self.poster.m2u(dist))
                 title = f"{title} {val} {self.poster.u()}"
             circle = dr.circle(center=(cx, cy), r=radius, fill=color)
             circle.set_desc(title=title)

--- a/run_page/gpxtrackposter/poster.py
+++ b/run_page/gpxtrackposter/poster.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import pytz
 import svgwrite
 
-from .utils import format_float
+from .utils import format_float, get_normalized_sport_type
 from .value_range import ValueRange
 from .xy import XY
 from .year_range import YearRange
@@ -73,6 +73,13 @@ _CHINESE_MONTH_NAMES = (
     "十二月",
 )
 
+_SPORT_SPECIAL_DISTANCES_KM = {
+    "cycling": (50.0, 100.0),
+    "running": (10.0, 20.0),
+    "hiking": (10.0, 20.0),
+}
+_DEFAULT_SPECIAL_DISTANCES_KM = (20.0, 50.0)
+
 
 class Poster:
     """Create a poster from track data.
@@ -112,7 +119,11 @@ class Poster:
             "special": "#FFFF00",
             "track": "#4DD2FF",
         }
-        self.special_distance = {"special_distance": 10, "special_distance2": 20}
+        self.special_distance = {
+            "special_distance": _DEFAULT_SPECIAL_DISTANCES_KM[0],
+            "special_distance2": _DEFAULT_SPECIAL_DISTANCES_KM[1],
+        }
+        self.use_sport_specific_distances = True
         self.width = 200
         self.height = 300
         self.years = None
@@ -159,6 +170,62 @@ class Poster:
 
     def year_title(self, year):
         return f"{year} {self.trans('Running')}"
+
+    def special_distance_thresholds(self, sport_type):
+        if not self.use_sport_specific_distances:
+            return (
+                self.special_distance["special_distance"],
+                self.special_distance["special_distance2"],
+            )
+
+        normalized_type = str(get_normalized_sport_type(sport_type) or "").lower()
+        if normalized_type == "walking":
+            normalized_type = "hiking"
+        return _SPORT_SPECIAL_DISTANCES_KM.get(
+            normalized_type, _DEFAULT_SPECIAL_DISTANCES_KM
+        )
+
+    def grade_distance(self, length_meters, sport_type):
+        distance = (
+            float(length_meters or 0) / 1000
+            if self.use_sport_specific_distances
+            else self.m2u(length_meters or 0)
+        )
+        yellow_distance, red_distance = self.special_distance_thresholds(sport_type)
+        if distance >= red_distance:
+            return 2
+        if distance >= yellow_distance:
+            return 1
+        return 0
+
+    def grade_track(self, track):
+        return self.grade_distance(track.length, track.type)
+
+    def day_grade(self, tracks):
+        if not self.use_sport_specific_distances:
+            return self.grade_distance(sum(track.length for track in tracks), None)
+        return max((self.grade_track(track) for track in tracks), default=0)
+
+    def special_distance_legend_labels(self):
+        if not self.use_sport_specific_distances:
+            yellow_distance, red_distance = self.special_distance_thresholds(None)
+            return (
+                f"{self.trans('Over')} {yellow_distance:g} {self.u()}",
+                f"{self.trans('Over')} {red_distance:g} {self.u()}",
+            )
+
+        cycling = _SPORT_SPECIAL_DISTANCES_KM["cycling"]
+        running = _SPORT_SPECIAL_DISTANCES_KM["running"]
+        default = _DEFAULT_SPECIAL_DISTANCES_KM
+        if self.is_chinese:
+            return (
+                f"骑{cycling[0]:g} 跑/徒{running[0]:g} 其他{default[0]:g} km",
+                f"骑{cycling[1]:g} 跑/徒{running[1]:g} 其他{default[1]:g} km",
+            )
+        return (
+            f"Bike{cycling[0]:g} Run/Hike{running[0]:g} Other{default[0]:g} km",
+            f"Bike{cycling[1]:g} Run/Hike{running[1]:g} Other{default[1]:g} km",
+        )
 
     def set_tracks(self, tracks):
         """Associate the set of tracks with this poster.
@@ -238,8 +305,7 @@ class Poster:
         value_style = "font-size:9px; font-family:Arial"
         small_value_style = "font-size:3px; font-family:Arial"
 
-        special_distance1 = self.special_distance["special_distance"]
-        special_distance2 = self.special_distance["special_distance2"]
+        special_label1, special_label2 = self.special_distance_legend_labels()
 
         (
             total_length,
@@ -281,7 +347,7 @@ class Poster:
 
             d.add(
                 d.text(
-                    f"{self.trans('Over')} {special_distance1:.1f} {self.u()}",
+                    special_label1,
                     insert=(70, self.height - 14.5),
                     fill=text_color,
                     style=small_value_style,
@@ -294,7 +360,7 @@ class Poster:
 
             d.add(
                 d.text(
-                    f"{self.trans('Over')} {special_distance2:.1f} {self.u()}",
+                    special_label2,
                     insert=(70, self.height - 10.5),
                     fill=text_color,
                     style=small_value_style,

--- a/run_page/gpxtrackposter/year_summary_drawer.py
+++ b/run_page/gpxtrackposter/year_summary_drawer.py
@@ -347,11 +347,11 @@ class YearSummaryDrawer(TracksDrawer):
     ):
         """Draw the monthly activity grid - 12 columns (months), 31 rows (days)"""
         # Group tracks by month and day
-        month_data = defaultdict(lambda: defaultdict(float))
-        for t in tracks:
-            month = t.start_time_local.month
-            day = t.start_time_local.day
-            month_data[month][day] += self.poster.m2u(t.length)
+        month_data = defaultdict(lambda: defaultdict(list))
+        for track in tracks:
+            month = track.start_time_local.month
+            day = track.start_time_local.day
+            month_data[month][day].append(track)
 
         # Grid parameters - 12 columns (months), 31 rows (days)
         cols = 12  # months
@@ -365,10 +365,9 @@ class YearSummaryDrawer(TracksDrawer):
         # Find max distance for color scaling
         max_dist = 1
         for month_days in month_data.values():
-            for dist in month_days.values():
-                max_dist = max(max_dist, dist)
-
-        special_distance = self.poster.special_distance.get("special_distance", 10)
+            for day_tracks in month_days.values():
+                distance = sum(self.poster.m2u(track.length) for track in day_tracks)
+                max_dist = max(max_dist, distance)
 
         # Draw dots - each column is a month, each row is a day
         for month in range(1, 13):
@@ -383,15 +382,19 @@ class YearSummaryDrawer(TracksDrawer):
                 cx = x_start + (month - 1) * spacing_x + spacing_x / 2
                 cy = y_start + (day - 1) * spacing_y + spacing_y / 2
 
-                dist = month_data[month].get(day, 0)
+                day_tracks = month_data[month].get(day, ())
+                dist = sum(self.poster.m2u(track.length) for track in day_tracks)
 
                 if dist > 0:
-                    # Activity day - color based on distance
-                    if dist >= special_distance:
+                    grade = self.poster.day_grade(day_tracks)
+                    if grade == 2:
+                        color = self.poster.colors.get(
+                            "special2"
+                        ) or self.poster.colors.get("special")
+                    elif grade == 1:
                         color = special_color
                     else:
-                        # Interpolate between dim and track color based on distance
-                        intensity = min(dist / special_distance, 1.0)
+                        intensity = min(dist / max_dist, 1.0)
                         color = self._interpolate_color(
                             dim_color, track_color, intensity
                         )

--- a/tests/test_deployment_config.py
+++ b/tests/test_deployment_config.py
@@ -125,6 +125,36 @@ class DataSyncConfigTest(unittest.TestCase):
             "Both English and Chinese GitHub-style year charts must be regenerated",
         )
 
+    def test_generated_charts_use_sport_specific_distance_defaults(self):
+        commands = [
+            line.strip()
+            for line in DATA_SYNC_WORKFLOW.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith("python run_page/gen_svg.py")
+        ]
+
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertNotIn(
+                    "--special-distance",
+                    command,
+                    "Active SVG generation commands must not force one threshold across sports",
+                )
+
+    def test_generated_charts_configure_both_special_colors(self):
+        commands = [
+            line.strip()
+            for line in DATA_SYNC_WORKFLOW.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith("python run_page/gen_svg.py")
+        ]
+
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIn(
+                    "--special-color2",
+                    command,
+                    "Every generated chart must distinguish yellow and red grades",
+                )
+
 
 class SecretLeakageTest(unittest.TestCase):
     """Ensure no plaintext Alibaba Cloud credentials leak into the repo."""

--- a/tests/test_special_distance.py
+++ b/tests/test_special_distance.py
@@ -1,0 +1,143 @@
+import datetime
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from types import SimpleNamespace
+
+from run_page.gpxtrackposter.poster import Poster
+from run_page.gpxtrackposter.github_drawer import GithubDrawer
+
+
+def make_track(distance_km, sport_type):
+    return SimpleNamespace(length=distance_km * 1000, type=sport_type)
+
+
+class SportSpecificDistanceTest(unittest.TestCase):
+    def setUp(self):
+        self.poster = Poster()
+
+    def test_each_sport_uses_its_own_inclusive_thresholds(self):
+        cases = (
+            ("cycling", 49.99, 0),
+            ("cycling", 50, 1),
+            ("Ride", 99.99, 1),
+            ("Ride", 100, 2),
+            ("running", 9.99, 0),
+            ("Run", 10, 1),
+            ("running", 20, 2),
+            ("hiking", 9.99, 0),
+            ("Walk", 10, 1),
+            ("walking", 20, 2),
+            ("multi_sport", 19.99, 0),
+            ("multi_sport", 20, 1),
+            ("other", 50, 2),
+        )
+
+        for sport_type, distance_km, expected_grade in cases:
+            with self.subTest(sport_type=sport_type, distance_km=distance_km):
+                self.assertEqual(
+                    self.poster.grade_track(make_track(distance_km, sport_type)),
+                    expected_grade,
+                )
+
+    def test_day_grade_takes_the_highest_individual_grade_without_summing(self):
+        self.assertEqual(
+            self.poster.day_grade(
+                (make_track(5, "running"), make_track(60, "cycling"))
+            ),
+            1,
+        )
+        self.assertEqual(
+            self.poster.day_grade(
+                (make_track(30, "cycling"), make_track(30, "cycling"))
+            ),
+            0,
+        )
+        self.assertEqual(
+            self.poster.day_grade(
+                (make_track(20, "running"), make_track(60, "cycling"))
+            ),
+            2,
+        )
+        self.assertEqual(self.poster.day_grade(()), 0)
+
+    def test_github_chart_colors_mixed_days_by_highest_individual_grade(self):
+        def dated_track(day, distance_km, sport_type):
+            return SimpleNamespace(
+                start_time_local=datetime.datetime(2026, 1, day),
+                length=distance_km * 1000,
+                type=sport_type,
+                subtype=None,
+            )
+
+        self.poster.athlete = "Test"
+        self.poster.title = "Test"
+        self.poster.height = 98
+        self.poster.drawer_type = "title"
+        self.poster.colors = {
+            "background": "#222222",
+            "text": "#ffffff",
+            "track": "#0000ff",
+            "track2": "#0000ff",
+            "special": "yellow",
+            "special2": "red",
+        }
+        self.poster.set_tracks(
+            (
+                dated_track(1, 5, "running"),
+                dated_track(1, 60, "cycling"),
+                dated_track(2, 30, "cycling"),
+                dated_track(2, 30, "cycling"),
+                dated_track(3, 20, "running"),
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "github.svg"
+            self.poster.draw(GithubDrawer(self.poster), output)
+            root = ET.parse(output).getroot()
+
+        namespace = "{http://www.w3.org/2000/svg}"
+        colors_by_date = {}
+        for rectangle in root.iter(f"{namespace}rect"):
+            title = rectangle.find(f"{namespace}title")
+            if title is not None and title.text and " " in title.text:
+                colors_by_date[title.text.split(" ", 1)[0]] = rectangle.get("fill")
+
+        self.assertEqual(colors_by_date["2026-01-01"], "yellow")
+        self.assertEqual(colors_by_date["2026-01-02"], "#0000ff")
+        self.assertEqual(colors_by_date["2026-01-03"], "red")
+
+    def test_explicit_legacy_thresholds_can_still_override_sport_rules(self):
+        self.poster.use_sport_specific_distances = False
+        self.poster.special_distance = {
+            "special_distance": 10,
+            "special_distance2": 20,
+        }
+
+        self.assertEqual(self.poster.grade_track(make_track(15, "cycling")), 1)
+        self.assertEqual(self.poster.grade_track(make_track(20, "cycling")), 2)
+        self.assertEqual(
+            self.poster.day_grade((make_track(6, "running"), make_track(6, "running"))),
+            1,
+        )
+        self.poster.units = "imperial"
+        self.assertEqual(self.poster.grade_track(make_track(20, "cycling")), 1)
+
+    def test_bilingual_legend_describes_all_active_categories(self):
+        self.assertEqual(
+            self.poster.special_distance_legend_labels(),
+            ("Bike50 Run/Hike10 Other20 km", "Bike100 Run/Hike20 Other50 km"),
+        )
+
+        self.poster.set_language("zh_CN")
+
+        self.assertEqual(
+            self.poster.special_distance_legend_labels(),
+            ("骑50 跑/徒10 其他20 km", "骑100 跑/徒20 其他50 km"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- grade cycling at 50/100 km, running and hiking/walking at 10/20 km, and other sports at 20/50 km
- grade each activity independently and use the highest daily/monthly grade so mixed sports are never summed across thresholds
- apply the same yellow/red rules to GitHub, grid, circular, year-summary, and month-of-life charts
- keep paired legacy CLI threshold overrides and add bilingual threshold legends

## Verification

- 74 pytest tests and 74 unittest tests
- 8 Vitest component tests and 2 Node tests
- Black, Ruff, Prettier, ESLint, Node 20, Vite production build
- real DB SVG generation across all affected drawers
- bilingual legend geometry check with no overlap