### PR TITLE
feat: default English and current-year map startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <script>

--- a/src/components/YearCharts/index.test.tsx
+++ b/src/components/YearCharts/index.test.tsx
@@ -24,7 +24,7 @@ vi.mock('@/utils/svgUtils', () => ({
 
 describe('YearCharts', () => {
   beforeEach(() => {
-    window.localStorage.setItem('language', 'zh-CN');
+    window.localStorage.setItem('language', 'en');
     vi.clearAllMocks();
   });
 
@@ -42,7 +42,7 @@ describe('YearCharts', () => {
   it('keeps both charts left-aligned inside one fixed slot', async () => {
     render(<YearCharts year="2026" />);
 
-    const slot = screen.getByRole('region', { name: '年度图表' });
+    const slot = screen.getByRole('region', { name: 'Year charts' });
     expect(slot).toHaveClass(
       'flex',
       'flex-col',
@@ -78,7 +78,7 @@ describe('YearCharts', () => {
 
   it('does not change layout on pointer movement and omits Total', async () => {
     const { rerender } = render(<YearCharts year="2026" />);
-    const slot = screen.getByRole('region', { name: '年度图表' });
+    const slot = screen.getByRole('region', { name: 'Year charts' });
     await within(slot).findByTestId('year-chart');
     const yearChart = within(slot).getByTestId('year-chart');
 
@@ -90,9 +90,9 @@ describe('YearCharts', () => {
     fireEvent.mouseOver(slot);
     fireEvent.mouseOut(slot);
 
-    expect(screen.getByRole('region', { name: '年度图表' })).toBe(slot);
+    expect(screen.getByRole('region', { name: 'Year charts' })).toBe(slot);
 
     rerender(<YearCharts year="Total" />);
-    expect(screen.queryByRole('region', { name: '年度图表' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Year charts' })).toBeNull();
   });
 });

--- a/src/components/YearStat/index.test.tsx
+++ b/src/components/YearStat/index.test.tsx
@@ -61,7 +61,7 @@ const statPairs = (container: HTMLElement): string[][] =>
 
 describe('YearStat charts', () => {
   beforeEach(() => {
-    window.localStorage.setItem('language', 'zh-CN');
+    window.localStorage.setItem('language', 'en');
     activityState.activities = [];
     activityState.years = ['2024', '2025'];
   });
@@ -69,7 +69,7 @@ describe('YearStat charts', () => {
   it('does not mix charts into an individual year summary', () => {
     render(<YearStat year="2025" onClick={vi.fn()} sportType="all" />);
 
-    expect(screen.queryByRole('region', { name: '年度图表' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Year charts' })).toBeNull();
   });
 
   it('places selected-year charts before overview copy and yearly summaries', async () => {
@@ -77,7 +77,7 @@ describe('YearStat charts', () => {
       <YearsStat year="2025" onClick={vi.fn()} sportType="all" />
     );
 
-    const slot = await screen.findByRole('region', { name: '年度图表' });
+    const slot = await screen.findByRole('region', { name: 'Year charts' });
     const wrapper = container.firstElementChild;
     expect(wrapper?.firstElementChild).toBe(slot);
     expect(await within(slot).findByTestId('year-chart')).toBeInTheDocument();
@@ -87,7 +87,7 @@ describe('YearStat charts', () => {
   it('does not show annual charts for the Total overview', () => {
     render(<YearsStat year="Total" onClick={vi.fn()} sportType="all" />);
 
-    expect(screen.queryByRole('region', { name: '年度图表' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Year charts' })).toBeNull();
   });
 
   it('calculates complete metrics and filters them by sport without losing labels', () => {
@@ -144,16 +144,16 @@ describe('YearStat charts', () => {
 
     expect(statPairs(container)).toEqual(
       expect.arrayContaining([
-        ['3', '次活动'],
+        ['3', 'Activities'],
         ['15', 'km'],
-        ['170', '海拔爬升 (m)'],
-        ['140', '海拔下降 (m)'],
-        ['500', '最高海拔 (m)'],
-        ['-20', '最低海拔 (m)'],
-        ['120', '平均心率'],
-        ['150', '平均功率 (W)'],
-        ['170', '加权功率 (W)'],
-        ['500', '最大功率 (W)'],
+        ['170', 'Elevation Gain (m)'],
+        ['140', 'Elevation Loss (m)'],
+        ['500', 'Highest Elev (m)'],
+        ['-20', 'Lowest Elev (m)'],
+        ['120', 'Avg Heart Rate'],
+        ['150', 'Avg Power (W)'],
+        ['170', 'Weighted Power (W)'],
+        ['500', 'Max Power (W)'],
       ])
     );
     fireEvent.click(screen.getByText('2025'));
@@ -162,9 +162,9 @@ describe('YearStat charts', () => {
     rerender(<YearStat year="2025" onClick={onClick} sportType="cycling" />);
     expect(statPairs(container)).toEqual(
       expect.arrayContaining([
-        ['2', '次活动'],
-        ['85', '平均踏频 (rpm)'],
-        ['110', '最大踏频 (rpm)'],
+        ['2', 'Activities'],
+        ['85', 'Avg Cadence (rpm)'],
+        ['110', 'Max Cadence (rpm)'],
       ])
     );
   });

--- a/src/pages/index.test.tsx
+++ b/src/pages/index.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const activityState = vi.hoisted(() => ({
+  activities: [
+    { run_id: 1, start_date_local: '2026-01-01T08:00:00' },
+    { run_id: 2, start_date_local: '2025-01-01T08:00:00' },
+  ],
+  years: ['2026', '2025'],
+  thisYear: '2026',
+}));
+
+vi.mock('@/components/Layout', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/LocationStat', () => ({
+  default: () => <div data-testid="location-stat" />,
+}));
+vi.mock('@/components/RunMap', () => ({
+  default: ({
+    thisYear,
+    geoData,
+  }: {
+    thisYear: string;
+    geoData: { features: unknown[] };
+  }) => (
+    <div
+      data-feature-count={geoData.features.length}
+      data-testid="run-map"
+      data-year={thisYear}
+    />
+  ),
+}));
+vi.mock('@/components/RunTable', () => ({
+  default: ({ runs }: { runs: unknown[] }) => (
+    <div data-run-count={runs.length} data-testid="run-table" />
+  ),
+}));
+vi.mock('@/components/SVGStat', () => ({
+  default: () => <div data-testid="total-svg-stat" />,
+}));
+vi.mock('@/components/YearsStat', () => ({
+  default: ({ year }: { year: string }) => (
+    <div data-testid="year-stats" data-year={year} />
+  ),
+}));
+vi.mock('@/hooks/useActivities', () => ({
+  default: () => activityState,
+}));
+vi.mock('@/hooks/useSiteMetadata', () => ({
+  default: () => ({ siteTitle: 'Running Page', siteUrl: '/' }),
+}));
+vi.mock('@/hooks/useInterval', () => ({
+  useInterval: vi.fn(),
+}));
+vi.mock('@/hooks/useTheme', () => ({
+  useThemeChangeCounter: () => 0,
+}));
+vi.mock('@/utils/utils', () => ({
+  filterAndSortRuns: (
+    activities: Array<{ start_date_local: string }>,
+    item: string,
+    filter: (run: { start_date_local: string }, value: string) => boolean
+  ) => activities.filter((run) => filter(run, item)),
+  filterCityRuns: () => true,
+  filterSportRuns: () => true,
+  filterTitleRuns: () => true,
+  filterYearRuns: (run: { start_date_local: string }, year: string) =>
+    year === 'Total' || run.start_date_local.startsWith(year),
+  geoJsonForRuns: (runs: unknown[]) => ({
+    type: 'FeatureCollection',
+    features: runs.map(() => ({
+      type: 'Feature',
+      properties: {},
+      geometry: { type: 'LineString', coordinates: [] },
+    })),
+  }),
+  getBoundsForGeoData: () => ({
+    latitude: 0,
+    longitude: 0,
+    zoom: 10,
+  }),
+  scrollToMap: vi.fn(),
+  sortDateFunc: () => 0,
+  titleForShow: () => '',
+}));
+
+import Index from './index';
+
+describe('home page startup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-09T08:00:00Z'));
+    activityState.activities = [
+      { run_id: 1, start_date_local: '2026-01-01T08:00:00' },
+      { run_id: 2, start_date_local: '2025-01-01T08:00:00' },
+    ];
+    activityState.years = ['2026', '2025'];
+    activityState.thisYear = '2026';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  it('opens the current calendar year and filters the map immediately', () => {
+    render(<Index />);
+
+    expect(screen.getByTestId('year-stats')).toHaveAttribute(
+      'data-year',
+      '2026'
+    );
+    expect(screen.getByTestId('run-map')).toHaveAttribute('data-year', '2026');
+    expect(screen.getByTestId('run-map')).toHaveAttribute(
+      'data-feature-count',
+      '1'
+    );
+  });
+
+  it('shows the current-year activity table instead of the all-years SVG', () => {
+    render(<Index />);
+
+    expect(screen.getByTestId('run-table')).toHaveAttribute(
+      'data-run-count',
+      '1'
+    );
+    expect(screen.queryByTestId('total-svg-stat')).toBeNull();
+  });
+
+  it('prefers the current calendar year when newer dated data exists', () => {
+    activityState.activities = [
+      { run_id: 1, start_date_local: '2027-01-01T08:00:00' },
+      { run_id: 2, start_date_local: '2026-01-01T08:00:00' },
+    ];
+    activityState.years = ['2027', '2026'];
+    activityState.thisYear = '2027';
+
+    render(<Index />);
+
+    expect(screen.getByTestId('year-stats')).toHaveAttribute(
+      'data-year',
+      '2026'
+    );
+    expect(screen.getByTestId('run-map')).toHaveAttribute(
+      'data-feature-count',
+      '1'
+    );
+  });
+
+  it('falls back to the latest activity year when the current year is absent', () => {
+    activityState.activities = [
+      { run_id: 1, start_date_local: '2025-01-01T08:00:00' },
+      { run_id: 2, start_date_local: '2024-01-01T08:00:00' },
+    ];
+    activityState.years = ['2025', '2024'];
+    activityState.thisYear = '2025';
+
+    render(<Index />);
+
+    expect(screen.getByTestId('year-stats')).toHaveAttribute(
+      'data-year',
+      '2025'
+    );
+    expect(screen.getByTestId('run-map')).toHaveAttribute(
+      'data-feature-count',
+      '1'
+    );
+  });
+});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,9 +28,13 @@ import { useThemeChangeCounter } from '@/hooks/useTheme';
 
 const Index = () => {
   const { siteTitle, siteUrl } = useSiteMetadata();
-  const { activities, thisYear } = useActivities();
+  const { activities, years, thisYear } = useActivities();
   const themeChangeCounter = useThemeChangeCounter();
-  const [year, setYear] = useState('Total');
+  const currentYear = new Date().getFullYear().toString();
+  const initialYear = years.includes(currentYear)
+    ? currentYear
+    : thisYear || 'Total';
+  const [year, setYear] = useState(initialYear);
   const [sportType, setSportType] = useState<SportTypeFilter>('all');
   const [runIndex, setRunIndex] = useState(-1);
   const [title, setTitle] = useState('');
@@ -41,7 +45,7 @@ const Index = () => {
   const [currentFilter, setCurrentFilter] = useState<{
     item: string;
     func: (_run: Activity, _value: string) => boolean;
-  }>({ item: 'Total', func: filterYearRuns });
+  }>({ item: initialYear, func: filterYearRuns });
 
   // State to track if we're showing a single run from URL hash
   const [singleRunId, setSingleRunId] = useState<number | null>(null);

--- a/src/utils/const.test.ts
+++ b/src/utils/const.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { LIGHTS_ON, PRIVACY_MODE } from '@/utils/const';
+
+describe('map startup configuration', () => {
+  it('shows base-map tiles automatically', () => {
+    expect(PRIVACY_MODE).toBe(false);
+    expect(LIGHTS_ON).toBe(true);
+  });
+});

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -44,15 +44,15 @@ const ROAD_LABEL_DISPLAY = true;
 // updated on 2024/11/17: privacy mode is set to true by default
 //set to `true` if you want to display only the routes without showing the map.
 const PRIVACY_MODE = false;
-// updated on 2024/11/17: lights are turned off by default
-//set to `false` if you want to make light off as default, only effect when `PRIVACY_MODE` = false
-const LIGHTS_ON = false;
+// Show the base map tiles on initial load.
+// Set to `false` to display routes without the base map by default.
+const LIGHTS_ON = true;
 //set to `true` if you want to show the 'Elevation Gain' column
 const SHOW_ELEVATION_GAIN = false;
 // richer title for the activity types (like garmin style)
 const RICH_TITLE = false;
 
-// Chinese is the default; the header language switch persists the preference.
+// English is the default; the header language switch persists the preference.
 const IS_CHINESE = getStoredLanguage() === 'zh-CN';
 const USE_ANIMATION_FOR_GRID = false;
 const CHINESE_INFO_MESSAGE = (yearLength: number, year: string): string => {

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -1,10 +1,10 @@
 export type Language = 'zh-CN' | 'en';
 
-export const DEFAULT_LANGUAGE: Language = 'zh-CN';
+export const DEFAULT_LANGUAGE: Language = 'en';
 export const LANGUAGE_STORAGE_KEY = 'language';
 
 export const resolveLanguage = (value: string | null): Language =>
-  value === 'en' ? 'en' : DEFAULT_LANGUAGE;
+  value === 'zh-CN' ? 'zh-CN' : DEFAULT_LANGUAGE;
 
 export const getStoredLanguage = (): Language => {
   if (typeof window === 'undefined') return DEFAULT_LANGUAGE;

--- a/tests/language.test.mjs
+++ b/tests/language.test.mjs
@@ -9,6 +9,10 @@ const source = await readFile(
   new URL('../src/utils/language.ts', import.meta.url),
   'utf8'
 );
+const indexHtml = await readFile(
+  new URL('../index.html', import.meta.url),
+  'utf8'
+);
 const { outputText } = ts.transpileModule(source, {
   compilerOptions: {
     module: ts.ModuleKind.ESNext,
@@ -19,11 +23,15 @@ const language = await import(
   `data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`
 );
 
-test('resolveLanguage defaults to Chinese and accepts English', () => {
-  assert.equal(language.resolveLanguage(null), 'zh-CN');
-  assert.equal(language.resolveLanguage('unsupported'), 'zh-CN');
+test('resolveLanguage defaults to English and accepts supported languages', () => {
+  assert.equal(language.resolveLanguage(null), 'en');
+  assert.equal(language.resolveLanguage('unsupported'), 'en');
   assert.equal(language.resolveLanguage('zh-CN'), 'zh-CN');
   assert.equal(language.resolveLanguage('en'), 'en');
+});
+
+test('document shell defaults to English', () => {
+  assert.match(indexHtml, /<html lang="en">/);
 });
 
 test('stored language is persisted and storage failures are safe', () => {
@@ -48,7 +56,7 @@ test('stored language is persisted and storage failures are safe', () => {
       throw new Error('storage unavailable');
     };
 
-    assert.equal(language.getStoredLanguage(), 'zh-CN');
+    assert.equal(language.getStoredLanguage(), 'en');
     assert.equal(language.persistLanguage('en'), false);
   } finally {
     if (originalWindow === undefined) {


### PR DESCRIPTION
## Summary

- default first-time visitors to English while preserving the persisted Chinese preference
- show base-map tiles automatically on initial load
- select the current calendar year when activity data exists, otherwise use the latest activity year
- filter map routes and the activity table to the selected startup year

## Verification

- 74 pytest and 74 unittest tests
- 13 Vitest component tests and 3 Node tests
- Node 20, Prettier, ESLint, Vite production build
- desktop/mobile English plus persisted-Chinese browser regression
- CARTO JSON/PNG tile requests confirmed on initial load